### PR TITLE
Refactor sync-to-private process in Makefile and GitHub Actions

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -17,4 +17,8 @@ jobs:
       run: sudo apt-get install -y make
 
     - name: Sync
-      run: make sync-to-private
+      run: |
+        git remote add origin-private https://wtsi-hgi:${{ secrets.DEPLOY_TOKEN }}@github.com/wtsi-hgi/wes-qc-analysis.git || true
+        make sync-to-private
+      env:
+        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,6 @@ clear-ht:
 
 
 sync-to-private:
-	if [ ! -f .git/config ] || ! git remote get-url origin | grep -q "wes-qc.git"; then \
-		echo "This is not the wes-qc repository"; \
-		exit 0; \
-	fi
 	git remote add origin-private git@github.com:wtsi-hgi/wes-qc-analysis.git || true
 	git switch main
 	git pull


### PR DESCRIPTION
- Removed repository check from the Makefile's sync-to-private target.
- Updated sync.yaml to include a secure method for adding the private repository remote using a GitHub secret for authentication.

This improves the flexibility and security of the sync process.