### PR TITLE
Rename 'build' job to 'sync' in GitHub Actions workflow for clarity a…

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
…nd consistency.