### PR TITLE
Dev relatedness check

### DIFF
--- a/0-resource_preparation/1-import_1kg.py
+++ b/0-resource_preparation/1-import_1kg.py
@@ -121,8 +121,8 @@ def main() -> None:
         kg_mt = hl.read_matrix_table(kg_unprocessed_mt_file)
         related_samples_to_remove = hl.read_table(samples_to_remove_file)
         kg_mt_remove_related = kg_remove_related_samples(kg_mt, related_samples_to_remove)
+        kg_mt_remove_related = filtering.filter_matrix_for_ldprune(kg_mt_remove_related, conf["long_range_ld_file"], **conf["filter_params"])
         kg_mt_remove_related.write(kg_mt_file, overwrite=True)
-
 
 if __name__ == "__main__":
     main()

--- a/0-resource_preparation/1-import_1kg.py
+++ b/0-resource_preparation/1-import_1kg.py
@@ -46,13 +46,10 @@ def create_1kg_mt(vcf_indir: str, kg_pop_file: str, **kwargs: dict) -> hl.Matrix
     return kg_unprocessed_mt
 
 
-def kg_filter_and_ldprune(
+def kg_filter(
     kg_unprocessed_mt: hl.MatrixTable,
+    filter_params: dict,
     long_range_ld_file: str,
-    call_rate_threshold: float,
-    af_threshold: float,
-    hwe_threshold: float,
-    r2_threshold: float,
     **kwargs,
 ) -> hl.MatrixTable:
     """
@@ -70,55 +67,10 @@ def kg_filter_and_ldprune(
     kg_mt_filtered = filtering.filter_matrix_for_ldprune(
         kg_unprocessed_mt,
         long_range_ld_file,
-        call_rate_threshold,
-        af_threshold,
-        hwe_threshold,
+        **filter_params
     )
     # LD pruning - removing variation regions that are related to each other
-    pruned_kg_ht = hl.ld_prune(kg_mt_filtered.GT, r2=r2_threshold)
-    pruned_kg_mt = kg_mt_filtered.filter_rows(hl.is_defined(pruned_kg_ht[kg_mt_filtered.row_key]))
-    pruned_kg_mt = pruned_kg_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_kg_mt.GT.n_alt_alleles()))
-    return pruned_kg_mt
-
-
-def run_pc_relate(
-    pruned_mt: hl.MatrixTable,
-    relatedness_ht_file,
-    scores_file: str,
-    pca_components: int,
-    kin_threshold: float,
-    hl_pc_related_kwargs=dict(),
-    **kwargs,
-) -> hl.Table:
-    """
-    Runs PC relate on pruned MT
-    :param str pruned_mt: matrixtable to prune
-    :param str relatedness_ht_file: relatedness ht file
-    :param str scores_file: file to wtire scores ht
-    :param int pca_components:  the number of principal components
-    :param dict hl_pc_related_kwargs: kwargs to pass to HL PC relate
-    """
-    if hl_pc_related_kwargs is None:
-        hl_pc_related_kwargs = {}
-    relatedness_ht_file = path_spark(relatedness_ht_file)
-    scores_file = path_spark(scores_file)
-
-    print("=== Running PC relate")
-    eig, scores, _ = hl.hwe_normalized_pca(pruned_mt.GT, k=pca_components, compute_loadings=False)
-    scores.write(scores_file, overwrite=True)
-
-    print("=== Calculating relatedness (this step usually takes a while)")
-    relatedness_ht = hl.pc_relate(
-        pruned_mt.GT,
-        scores_expr=scores[pruned_mt.col_key].scores,
-        **hl_pc_related_kwargs,
-    )
-    relatedness_ht.write(relatedness_ht_file, overwrite=True)
-    # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
-    pairs = relatedness_ht.filter(relatedness_ht["kin"] > kin_threshold)
-    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
-    return related_samples_to_remove
-
+    return kg_mt_filtered
 
 def kg_remove_related_samples(kg_mt: hl.MatrixTable, related_samples_to_remove: hl.Table) -> hl.MatrixTable:
     variants, samples = kg_mt.count()
@@ -147,6 +99,82 @@ def get_options() -> Any:
     args = parser.parse_args()
     return args
 
+def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
+    """
+    Splits multiallelic sites and runs ld pruning
+    Filter to autosomes before LD pruning to decrease sample size - autosomes only wanted for later steps
+    :param MatrixTable mt: input MT containing variants to be pruned
+    :param dict config:
+    :return: Pruned MatrixTable
+    :rtype: hl.MatrixTable
+
+    `hl.ld_prune` returns a maximal subset of variants that are nearly uncorrelated within each window.
+    Requires the dataset to contain only diploid genotype calls and no multiallelic variants.
+    See also: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+    """
+
+    print("=== Filtering to autosomes")
+    mt = mt.filter_rows(mt.locus.in_autosome())
+    print("=== Splitting multiallelic sites")
+    mt = hail_patches.split_multi_hts(
+        mt, recalculate_gq=False
+    )  # this shouldn't do anything as only biallelic sites are used
+    print("=== Performing LD pruning")
+    pruned_ht = hl.ld_prune(mt.GT, **ld_prune_args)
+    pruned_mt = mt.filter_rows(hl.is_defined(pruned_ht[mt.row_key]))
+    pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
+    return pruned_mt
+
+def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
+    print("=== LD pruning before KING")
+    pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
+    pruned_mt.write(path_spark(prune_args["pruned_kg_file"]), overwrite=True)
+    print("=== Running KING")
+    king_mt = hl.king(pruned_mt.GT)
+    king_ht=king_mt.entries()
+    king_ht.write(path_spark(king_args["king_kg_file"]), overwrite=True)
+    related_pairs_ht = king_ht.filter((king_ht.phi > king_args["kinship_threshold"]) & (king_ht.s_1!=king_ht.s))
+    print("=== Identifying related samples")
+    samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
+    unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
+    related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
+    print("=== LD pruning unrelated samples")
+    pruned_unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
+    pruned_unrelated_mt.write(path_spark(king_args["unrelated_kg_king_file"]), overwrite=True)
+    related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
+    related_mt.write(path_spark(king_args["related_kg_king_file"]), overwrite=True)
+    return related_mt, pruned_unrelated_mt
+
+def run_pc_project(mt_ref, mt_study, pca_components):
+    print("=== Running PCA")
+    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
+    pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()
+    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
+
+    print("=== Running PC projection")
+    projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
+    union_pca_scores = pca_scores.union(projection_pca_scores)
+
+    return union_pca_scores, pca_scores, pca_loadings
+
+def prune_pc_relate(
+    mt: hl.MatrixTable, prune_params: dict, king_params: dict, pc_relate_params: dict,  **kwargs
+) -> hl.Table:
+    print("=== Running KING")
+    related_mt, unrelated_mt= run_king(mt, king_params, prune_params)
+    print("=== Running PCA")
+    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, **pc_relate_params)
+    union_pca_scores.write(path_spark(pc_relate_params["scores_file"]), overwrite=True)
+    pca_scores.write(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
+    pca_loadings.write(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)
+    print("=== Calculating relatedness")
+    pruned_mt = related_mt.union_cols(unrelated_mt)#check If i should use this or just prune the whole filtered mt
+    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
+    relatedness_ht.write(path_spark(pc_relate_params["relatedness_ht_file"]), overwrite=True)
+    # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
+    pairs = relatedness_ht.filter(relatedness_ht[pc_relate_params["relatedness_column"]] > pc_relate_params["relatedness_threshold"])
+    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
+    return related_samples_to_remove
 
 def main() -> None:
     # = STEP SETUP = #
@@ -168,7 +196,7 @@ def main() -> None:
 
     # = STEP OUTPUTS = #
     kg_unprocessed_mt_file = path_spark(conf["kg_unprocessed"])
-    pruned_kg_file = path_spark(conf["pruned_kg_file"])
+    filtered_kg_file= path_spark(conf["filtered_kg_file"])
     samples_to_remove_file = path_spark(conf["samples_to_remove_file"])
     kg_mt_file = path_spark(conf["kg_out_mt"])
 
@@ -182,12 +210,15 @@ def main() -> None:
 
     if args.kg_filter_and_prune:
         kg_unprocessed_mt = hl.read_matrix_table(kg_unprocessed_mt_file)
-        pruned_kg_mt = kg_filter_and_ldprune(kg_unprocessed_mt, **conf)
-        pruned_kg_mt.write(pruned_kg_file, overwrite=True)
+        filtered_kg_mt = kg_filter(kg_unprocessed_mt, **conf)
+        filtered_kg_mt.write(filtered_kg_file, overwrite=True)
 
     if args.kg_pc_relate:
-        pruned_kg_mt = hl.read_matrix_table(pruned_kg_file)
-        related_samples_to_remove = run_pc_relate(pruned_kg_mt, **conf)
+        filtered_kg_mt = hl.read_matrix_table(filtered_kg_file)
+        related_samples_to_remove = prune_pc_relate(
+            filtered_kg_mt, **conf
+        )
+
         related_samples_to_remove.write(samples_to_remove_file, overwrite=True)
 
     if args.kg_remove_related_samples:

--- a/0-resource_preparation/1-import_1kg.py
+++ b/0-resource_preparation/1-import_1kg.py
@@ -18,8 +18,8 @@ import hail as hl  # type: ignore
 
 from wes_qc.hail_utils import path_spark
 from wes_qc.config import get_config
-from wes_qc import filtering, hail_utils, hail_patches
-from gnomad.sample_qc.ancestry import pc_project
+from wes_qc.compute_relatedness import prune_pc_relate
+from wes_qc import filtering, hail_utils
 
 def create_1kg_mt(vcf_indir: str, kg_pop_file: str, **kwargs: dict) -> hl.MatrixTable:
     """
@@ -44,33 +44,6 @@ def create_1kg_mt(vcf_indir: str, kg_pop_file: str, **kwargs: dict) -> hl.Matrix
     kg_unprocessed_mt = kg_unprocessed_mt.key_cols_by(kg_unprocessed_mt.s)
 
     return kg_unprocessed_mt
-
-
-def kg_filter(
-    kg_unprocessed_mt: hl.MatrixTable,
-    filter_params: dict,
-    long_range_ld_file: str,
-    **kwargs,
-) -> hl.MatrixTable:
-    """
-    Filter and prune the 1kg data
-    :param kg_unprocessed_mt: The KG MT to filter and prune
-    :param long_range_ld_file: The long range LD file
-    :param call_rate_threshold: The call rate threshold
-    :param af_threshold: The allele frequency threshold
-    :param hwe_threshold: The HWE threshold
-    :param r2_threshold: Squared correlation threshold: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
-    :return: The filtered and pruned 1kg MT
-    """
-    long_range_ld_file = path_spark(long_range_ld_file)
-    # Filtering for good variations to make LD prune
-    kg_mt_filtered = filtering.filter_matrix_for_ldprune(
-        kg_unprocessed_mt,
-        long_range_ld_file,
-        **filter_params
-    )
-    # LD pruning - removing variation regions that are related to each other
-    return kg_mt_filtered
 
 def kg_remove_related_samples(kg_mt: hl.MatrixTable, related_samples_to_remove: hl.Table) -> hl.MatrixTable:
     variants, samples = kg_mt.count()
@@ -98,83 +71,6 @@ def get_options() -> Any:
     parser.add_argument("--all", help="Run All steps", action="store_true")
     args = parser.parse_args()
     return args
-
-def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
-    """
-    Splits multiallelic sites and runs ld pruning
-    Filter to autosomes before LD pruning to decrease sample size - autosomes only wanted for later steps
-    :param MatrixTable mt: input MT containing variants to be pruned
-    :param dict config:
-    :return: Pruned MatrixTable
-    :rtype: hl.MatrixTable
-
-    `hl.ld_prune` returns a maximal subset of variants that are nearly uncorrelated within each window.
-    Requires the dataset to contain only diploid genotype calls and no multiallelic variants.
-    See also: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
-    """
-
-    print("=== Filtering to autosomes")
-    mt = mt.filter_rows(mt.locus.in_autosome())
-    print("=== Splitting multiallelic sites")
-    mt = hail_patches.split_multi_hts(
-        mt, recalculate_gq=False
-    )  # this shouldn't do anything as only biallelic sites are used
-    print("=== Performing LD pruning")
-    pruned_ht = hl.ld_prune(mt.GT, **ld_prune_args)
-    pruned_mt = mt.filter_rows(hl.is_defined(pruned_ht[mt.row_key]))
-    pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
-    return pruned_mt
-
-def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
-    print("=== LD pruning before KING")
-    pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
-    pruned_mt.write(path_spark(prune_args["pruned_kg_file"]), overwrite=True)
-    print("=== Running KING")
-    king_mt = hl.king(pruned_mt.GT)
-    king_ht=king_mt.entries()
-    king_ht.write(path_spark(king_args["king_kg_file"]), overwrite=True)
-    related_pairs_ht = king_ht.filter((king_ht.phi > king_args["kinship_threshold"]) & (king_ht.s_1!=king_ht.s))
-    print("=== Identifying related samples")
-    samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
-    unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
-    related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
-    print("=== LD pruning unrelated samples")
-    pruned_unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
-    pruned_unrelated_mt.write(path_spark(king_args["unrelated_kg_king_file"]), overwrite=True)
-    related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
-    related_mt.write(path_spark(king_args["related_kg_king_file"]), overwrite=True)
-    return related_mt, pruned_unrelated_mt
-
-def run_pc_project(mt_ref, mt_study, pca_components):
-    print("=== Running PCA")
-    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
-    pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()
-    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
-
-    print("=== Running PC projection")
-    projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
-    union_pca_scores = pca_scores.union(projection_pca_scores)
-
-    return union_pca_scores, pca_scores, pca_loadings
-
-def prune_pc_relate(
-    mt: hl.MatrixTable, prune_params: dict, king_params: dict, pc_relate_params: dict,  **kwargs
-) -> hl.Table:
-    print("=== Running KING")
-    related_mt, unrelated_mt= run_king(mt, king_params, prune_params)
-    print("=== Running PCA")
-    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pc_relate_params["pca_components"])
-    union_pca_scores.write(path_spark(pc_relate_params["scores_file"]), overwrite=True)
-    pca_scores.write(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
-    pca_loadings.write(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)
-    print("=== Calculating relatedness")
-    pruned_mt = related_mt.union_cols(unrelated_mt)#check If i should use this or just prune the whole filtered mt
-    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_params["pc_relate_args"])
-    relatedness_ht.write(path_spark(pc_relate_params["relatedness_ht_file"]), overwrite=True)
-    # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
-    pairs = relatedness_ht.filter(relatedness_ht[pc_relate_params["relatedness_column"]] > pc_relate_params["relatedness_threshold"])
-    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
-    return related_samples_to_remove
 
 def main() -> None:
     # = STEP SETUP = #
@@ -210,13 +106,13 @@ def main() -> None:
 
     if args.kg_filter_and_prune:
         kg_unprocessed_mt = hl.read_matrix_table(kg_unprocessed_mt_file)
-        filtered_kg_mt = kg_filter(kg_unprocessed_mt, **conf)
+        filtered_kg_mt = filtering.filter_matrix_for_ldprune(kg_unprocessed_mt, conf["long_range_ld_file"], **conf["filter_params"])
         filtered_kg_mt.write(filtered_kg_file, overwrite=True)
 
     if args.kg_pc_relate:
         filtered_kg_mt = hl.read_matrix_table(filtered_kg_file)
-        related_samples_to_remove = prune_pc_relate(
-            filtered_kg_mt, **conf
+        related_samples_to_remove, _ = prune_pc_relate(
+            filtered_kg_mt, conf["prune_params"], conf["king_params"], conf["pc_relate_params"], "ref"
         )
 
         related_samples_to_remove.write(samples_to_remove_file, overwrite=True)

--- a/0-resource_preparation/1-import_1kg.py
+++ b/0-resource_preparation/1-import_1kg.py
@@ -18,8 +18,8 @@ import hail as hl  # type: ignore
 
 from wes_qc.hail_utils import path_spark
 from wes_qc.config import get_config
-from wes_qc import filtering, hail_utils
-
+from wes_qc import filtering, hail_utils, hail_patches
+from gnomad.sample_qc.ancestry import pc_project
 
 def create_1kg_mt(vcf_indir: str, kg_pop_file: str, **kwargs: dict) -> hl.MatrixTable:
     """
@@ -163,13 +163,13 @@ def prune_pc_relate(
     print("=== Running KING")
     related_mt, unrelated_mt= run_king(mt, king_params, prune_params)
     print("=== Running PCA")
-    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, **pc_relate_params)
+    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pc_relate_params["pca_components"])
     union_pca_scores.write(path_spark(pc_relate_params["scores_file"]), overwrite=True)
     pca_scores.write(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
     pca_loadings.write(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)
     print("=== Calculating relatedness")
     pruned_mt = related_mt.union_cols(unrelated_mt)#check If i should use this or just prune the whole filtered mt
-    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
+    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_params["pc_relate_args"])
     relatedness_ht.write(path_spark(pc_relate_params["relatedness_ht_file"]), overwrite=True)
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
     pairs = relatedness_ht.filter(relatedness_ht[pc_relate_params["relatedness_column"]] > pc_relate_params["relatedness_threshold"])

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -43,19 +43,19 @@ def run_filtering(mt: hl.MatrixTable, long_range_ld_file, call_rate_threshold, a
 
 def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
     print("=== LD pruning before KING")
-    pruned_mt= prune_mt(mt, **prune_args)
+    pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
     pruned_mt.write(path_spark(prune_args["pruned_mt_file"]), overwrite=True)
     print("=== Running KING")
     king_mt = hl.king(pruned_mt.GT)
     king_ht=king_mt.entries()
     king_ht.write(path_spark(king_args["king_output_file"]), overwrite=True)
-    related_pairs_ht = king_ht.filter(((king_ht.phi > king_args["kinship_threshold"]) | (king_ht.phi < king_args["divergence_threshold"])) & (king_ht.s_1!=king_ht.s))
+    related_pairs_ht = king_ht.filter((king_ht.phi > king_args["kinship_threshold"]) & (king_ht.s_1!=king_ht.s))
     print("=== Identifying related samples")
     samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
     unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
     related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
     print("=== LD pruning unrelated samples")
-    pruned_unrelated_mt = prune_mt(unrelated_mt, **prune_args)
+    pruned_unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
     pruned_unrelated_mt.write(path_spark(king_args["unrelated_king_file"]), overwrite=True)
     related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
     related_mt.write(path_spark(king_args["related_king_file"]), overwrite=True)
@@ -108,7 +108,7 @@ def run_population_pca(
     filtered_mt: hl.MatrixTable,
     samples_to_remove: hl.Table,
     prune_args: dict,
-    plink_outfile,
+#    plink_outfile,
     pca_components,
     plot_outfile,
     **kwargs,
@@ -129,7 +129,7 @@ def run_population_pca(
     #plink_mt = unrelated_mt.annotate_cols(uid=unrelated_mt.s).key_cols_by("uid")
     #hl.export_plink(dataset=plink_mt, output=path_spark(plink_outfile), fam_id=plink_mt.uid, ind_id=plink_mt.uid)
     print("=== Running LD pruning before PCA")
-    unrelated_mt = prune_mt(unrelated_mt, **prune_args)
+    unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
     unrelated_mt.write(path_spark(prune_args["pruned_unrelated_pcrelate_file"]), overwrite=True)
     related_mt = related_mt.semi_join_rows(unrelated_mt.rows())
 
@@ -165,15 +165,13 @@ def main():
     pltdir = path_local(config["general"]["plots_dir"])
     if not os.path.exists(pltdir):
         os.makedirs(pltdir)
-
     # load input mt
     mt = hl.read_matrix_table(path_spark(mt_infile))
     #removing control samples
     mt= filtering.remove_samples(mt, control_list)
     #filter matrix to have good variants
     filtered_mt = run_filtering(mt, **config["step2"]["filter_before_pruning"])
-    filtered_mt.write(path_spark(config["step2"]["filter_before_pruning"]["filtered_mt_outfile"]), overwrite=True)
-
+    filtered_mt.write(path_spark(config["step2"]["filtered_mt_outfile"]), overwrite=True)
     # run pcrelate
     related_samples_to_remove_ht, scores, unrelated_scores, loadings, relatedness_ht = prune_pc_relate(
         filtered_mt, config["step2"]["prune"], config["step2"]["king"], **config["step2"]["prune_pc_relate"]
@@ -192,7 +190,6 @@ def main():
 
     # plot relatedness
     plot_relatedness(relatedness_ht, **config["step2"]["prune_pc_relate"])
-
     # run PCA
     pca_mt, union_pca_scores, pca_scores, pca_loadings = run_population_pca(
         filtered_mt, related_samples_to_remove_ht, config["step2"]["prune"], **config["step2"]["prune_plot_pca"]

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -59,7 +59,7 @@ def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.Matri
     pruned_unrelated_mt.write(path_spark(king_args["unrelated_king_file"]), overwrite=True)
     related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
     related_mt.write(path_spark(king_args["related_king_file"]), overwrite=True)
-    return related_mt, pruned_unrelated_mt, pruned_mt
+    return related_mt, pruned_unrelated_mt
 
 def run_pc_project(mt_ref, mt_study, pca_components):
     print("=== Running PCA")
@@ -76,10 +76,11 @@ def prune_pc_relate(
     mt: hl.MatrixTable, prune_args: dict, king_args: dict, pca_components: int, pc_relate_args: dict, relatedness_column: str, relatedness_threshold: float, **kwargs
 ) -> (hl.Table, hl.Table, hl.Table, hl.Table, hl.Table):
     print("=== Running KING")
-    related_mt, unrelated_mt, pruned_mt= run_king(mt, king_args, prune_args)
+    related_mt, unrelated_mt = run_king(mt, king_args, prune_args)
     print("=== Running PCA")
     union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pca_components)
     print("=== Calculating relatedness")
+    pruned_mt = related_mt.union_cols(unrelated_mt)
     relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
     pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -108,7 +108,7 @@ def main():
     relatedness_ht.export(path_spark(config["step2"]["relatedness_output"]["relatedness_outfile"]))
 
     # plot relatedness
-    plot_relatedness(relatedness_ht, **config["step2"]["relatedness_output"]["relatedness_plotfile"])
+    plot_relatedness(relatedness_ht, config["step2"]["relatedness_output"]["relatedness_plotfile"])
     # run PCA
     pca_mt, union_pca_scores, pca_scores, pca_loadings = run_population_pca(
         filtered_mt, related_samples_to_remove_ht, config["step2"]["prune_params"], **config["step2"]["prune_plot_pca"]

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -56,7 +56,7 @@ def run_population_pca(
     unrelated_mt=unrelated_mt.checkpoint(path_spark(pruned_unrelated_pcrelate_file), overwrite=True)
     related_mt = related_mt.semi_join_rows(unrelated_mt.rows())
 
-    union_pca_scores, pca_scores, pca_loadings=run_pc_project(unrelated_mt, related_mt, pca_components)
+    union_pca_scores, pca_scores, pca_loadings, _ =run_pc_project(unrelated_mt, related_mt, pca_components)
     
     pca_mt = filtered_mt.annotate_cols(scores=union_pca_scores[filtered_mt.col_key].scores)
     print("=== Plotting PC1 vs PC2")

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -73,8 +73,8 @@ def run_pc_project(mt_ref, mt_study, pca_components):
     return union_pca_scores, pca_scores, pca_loadings
 
 def prune_pc_relate(
-    mt: hl.MatrixTable, prune_args: dict, king_args: dict, pca_components: int, pc_relate_args: dict, **kwargs
-) -> (hl.Table, hl.Table, hl.Table):
+    mt: hl.MatrixTable, prune_args: dict, king_args: dict, pca_components: int, pc_relate_args: dict, relatedness_column: str, relatedness_threshold: float, **kwargs
+) -> (hl.Table, hl.Table, hl.Table, hl.Table, hl.Table):
     print("=== Running KING")
     related_mt, unrelated_mt, pruned_mt= run_king(mt, king_args, prune_args)
     print("=== Running PCA")
@@ -170,9 +170,9 @@ def main():
     mt = hl.read_matrix_table(path_spark(mt_infile))
     #removing control samples
     mt= filtering.remove_samples(mt, control_list)
-    mt_filtered.write(path_spark(config["step2"]["filter_before_pruning"]["filtered_mt_outfile"]), overwrite=True)
     #filter matrix to have good variants
     filtered_mt = run_filtering(mt, **config["step2"]["filter_before_pruning"])
+    filtered_mt.write(path_spark(config["step2"]["filter_before_pruning"]["filtered_mt_outfile"]), overwrite=True)
 
     # run pcrelate
     related_samples_to_remove_ht, scores, unrelated_scores, loadings, relatedness_ht = prune_pc_relate(

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -34,44 +34,57 @@ def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
     pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
     return pruned_mt
 
+def run_filtering(mt: hl.MatrixTable, long_range_ld_file, call_rate_threshold, af_threshold, hwe_threshold) -> hl.MatrixTable:
+    print("=== Filtering")
+    filtered_mt = filtering.filter_matrix_for_ldprune(
+        mt, path_spark(long_range_ld_file), call_rate_threshold, af_threshold, hwe_threshold
+    )
+    return filtered_mt
+
+def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
+    print("=== LD pruning before KING")
+    pruned_mt= prune_mt(mt, **prune_args)
+    pruned_mt.write(path_spark(prune_args["pruned_mt_file"]), overwrite=True)
+    print("=== Running KING")
+    king_mt = hl.king(pruned_mt.GT)
+    king_ht=king_mt.entries()
+    king_ht.write(path_spark(king_args["king_output_file"]), overwrite=True)
+    related_pairs_ht = king_ht.filter(((king_ht.phi > king_args["kinship_threshold"]) | (king_ht.phi < king_args["divergence_threshold"])) & (king_ht.s_1!=king_ht.s))
+    print("=== Identifying related samples")
+    samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
+    unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
+    related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
+    print("=== LD pruning unrelated samples")
+    pruned_unrelated_mt = prune_mt(unrelated_mt, **prune_args)
+    pruned_unrelated_mt.write(path_spark(king_args["unrelated_king_file"]), overwrite=True)
+    related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
+    related_mt.write(path_spark(king_args["related_king_file"]), overwrite=True)
+    return related_mt, pruned_unrelated_mt, pruned_mt
+
+def run_pc_project(mt_ref, mt_study, pca_components):
+    print("=== Running PCA")
+    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
+    pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()
+    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
+    print("=== Running PC projection")
+    projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
+    union_pca_scores = pca_scores.union(projection_pca_scores)
+
+    return union_pca_scores, pca_scores, pca_loadings
 
 def prune_pc_relate(
-    pruned_mt: hl.MatrixTable, pca_components, pc_relate_args, relatedness_column, relatedness_threshold, **kwargs
+    mt: hl.MatrixTable, prune_args: dict, king_args: dict, pca_components: int, pc_relate_args: dict, **kwargs
 ) -> (hl.Table, hl.Table, hl.Table):
-    """
-    Runs PC relate on pruned MT
-    :param hl.MatrixTable pruned_mt: ld pruned MT file
-    :param dict config:
-    :return: mt with a column of too related samples to remove
-    :rtype: hl.MatrixTable
-
-    See https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
-
-    ### Config fields
-    step2.pc_relate.relatedness_ht_file : output path : relatedness ht file
-    step2.pc_relate.samples_to_remove_file : output path : ht file with a list of samples to remove
-    step2.pc_relate.scores_file : output path: : ht file with hwe_normalized_pca scores
-    step2.pc_relate.pca_components : int : number of components for the hwe_normalized_pca
-    step2.pc_relate.relatedness_column : str : pc_relate output column to use when applying the relatedness_threshold
-    step2.pc_relate.relatedness_threshold : float : samples with relatedness_column greater than relatedness_threshold are to be removed
-
-    ### Optional config fields
-    step2.pc_relate.pc_relate_args.min_individual_maf : float
-    step2.pc_relate.pc_relate_args.block_size : float
-    step2.pc_relate.pc_relate_args.min_kinship : float
-    step2.pc_relate.pc_relate_args.statistics : str
-    step2.pc_relate.pc_relate_args.k : int
-    step2.pc_relate.pc_relate_args.include_self_kinship : bool
-    """
-
-    print("=== Running PC relate")
-    eig, scores, _ = hl.hwe_normalized_pca(pruned_mt.GT, k=pca_components, compute_loadings=False)
+    print("=== Running KING")
+    related_mt, unrelated_mt, pruned_mt= run_king(mt, king_args, prune_args)
+    print("=== Running PCA")
+    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pca_components)
     print("=== Calculating relatedness")
-    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=scores[pruned_mt.col_key].scores, **pc_relate_args)
+    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
     pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)
     related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
-    return related_samples_to_remove, scores, relatedness_ht
+    return related_samples_to_remove, union_pca_scores, pca_scores, pca_loadings, relatedness_ht
 
 
 def plot_relatedness(
@@ -92,8 +105,9 @@ def plot_relatedness(
 
 # TODO: How is this step different from 2-sample_qc/3-population_pca_prediction.py/run_pca()? Only PCA plotting?
 def run_population_pca(
-    pruned_mt: hl.MatrixTable,
+    filtered_mt: hl.MatrixTable,
     samples_to_remove: hl.Table,
+    prune_args: dict,
     plink_outfile,
     pca_components,
     plot_outfile,
@@ -105,25 +119,23 @@ def run_population_pca(
     """
     print("=== Running population PCA")
     print("=== Spliting samples")
-    unrelated_mt = pruned_mt.filter_cols(hl.is_defined(samples_to_remove[pruned_mt.col_key]), keep=False)
-    related_mt = pruned_mt.filter_cols(hl.is_defined(samples_to_remove[pruned_mt.col_key]))
+    unrelated_mt = filtered_mt.filter_cols(hl.is_defined(samples_to_remove[filtered_mt.col_key]), keep=False)
+    related_mt = filtered_mt.filter_cols(hl.is_defined(samples_to_remove[filtered_mt.col_key]))
     variants, samples = unrelated_mt.count()
     print(f"=== {samples} samples for PCA")
     variants, samples = related_mt.count()
     print(f"=== {samples} samples for PC projection")
     #Why do we need plink files?
-    plink_mt = unrelated_mt.annotate_cols(uid=unrelated_mt.s).key_cols_by("uid")
-    hl.export_plink(dataset=plink_mt, output=path_spark(plink_outfile), fam_id=plink_mt.uid, ind_id=plink_mt.uid)
-    print("=== Running PCA")
-    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(unrelated_mt.GT, k=pca_components, compute_loadings=True)
-    pca_af_ht = unrelated_mt.annotate_rows(pca_af=hl.agg.mean(unrelated_mt.GT.n_alt_alleles()) / 2).rows()
-    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
-    print("=== Running PC projection")
-    projection_pca_scores = pc_project(related_mt, pca_loadings, loading_location="loadings", af_location="pca_af")
-    union_pca_scores = pca_scores.union(projection_pca_scores)
+    #plink_mt = unrelated_mt.annotate_cols(uid=unrelated_mt.s).key_cols_by("uid")
+    #hl.export_plink(dataset=plink_mt, output=path_spark(plink_outfile), fam_id=plink_mt.uid, ind_id=plink_mt.uid)
+    print("=== Running LD pruning before PCA")
+    unrelated_mt = prune_mt(unrelated_mt, **prune_args)
+    unrelated_mt.write(path_spark(prune_args["pruned_unrelated_pcrelate_file"]), overwrite=True)
+    related_mt = related_mt.semi_join_rows(unrelated_mt.rows())
+
+    union_pca_scores, pca_scores, pca_loadings=run_pc_project(unrelated_mt, related_mt, pca_components)
     
-    
-    pca_mt = pruned_mt.annotate_cols(scores=union_pca_scores[pruned_mt.col_key].scores)
+    pca_mt = filtered_mt.annotate_cols(scores=union_pca_scores[filtered_mt.col_key].scores)
     print("=== Plotting PC1 vs PC2")
     os.makedirs(os.path.dirname(plot_outfile), exist_ok=True)
     p = hl.plot.scatter(pca_mt.scores[0], pca_mt.scores[1], title="PCA", xlabel="PC1", ylabel="PC2")
@@ -158,16 +170,20 @@ def main():
     mt = hl.read_matrix_table(path_spark(mt_infile))
     #removing control samples
     mt= filtering.remove_samples(mt, control_list)
-    # ld prune to get a table of variants which are not correlated
-    pruned_mt = prune_mt(mt, **config["step2"]["prune"])
-    pruned_mt.write(path_spark(mtoutfile), overwrite=True)
+    mt_filtered.write(path_spark(config["step2"]["filter_before_pruning"]["filtered_mt_outfile"]), overwrite=True)
+    #filter matrix to have good variants
+    filtered_mt = run_filtering(mt, **config["step2"]["filter_before_pruning"])
 
     # run pcrelate
-    related_samples_to_remove_ht, scores, relatedness_ht = prune_pc_relate(
-        pruned_mt, **config["step2"]["prune_pc_relate"]
+    related_samples_to_remove_ht, scores, unrelated_scores, loadings, relatedness_ht = prune_pc_relate(
+        filtered_mt, config["step2"]["prune"], config["step2"]["king"], **config["step2"]["prune_pc_relate"]
     )
-    scores_file = config["step2"]["prune_pc_relate"]["scores_file"]
-    scores.write(path_spark(scores_file), overwrite=True)  # output
+    scores_file1 = config["step2"]["prune_pc_relate"]["scores_file"]
+    scores_file2 = config["step2"]["prune_pc_relate"]["unrelated_samples_scores_file"]
+    loadings_file = config["step2"]["prune_pc_relate"]["pca_loadings_file_pc_relate"]
+    scores.write(path_spark(scores_file1), overwrite=True)  # output
+    unrelated_scores.write(path_spark(scores_file2), overwrite=True)  # output
+    loadings.write(path_spark(loadings_file), overwrite=True)  # output
     related_samples_to_remove_ht.write(
         path_spark(config["step2"]["prune_pc_relate"]["samples_to_remove_file"]), overwrite=True
     )
@@ -179,7 +195,7 @@ def main():
 
     # run PCA
     pca_mt, union_pca_scores, pca_scores, pca_loadings = run_population_pca(
-        pruned_mt, related_samples_to_remove_ht, **config["step2"]["prune_plot_pca"]
+        filtered_mt, related_samples_to_remove_ht, config["step2"]["prune"], **config["step2"]["prune_plot_pca"]
     )
     pca_mt.write(path_spark(config["step2"]["prune_plot_pca"]["pca_mt_file"]), overwrite=True)
     union_pca_scores.write(path_spark(config["step2"]["prune_plot_pca"]["union_pca_scores_file"]), overwrite=True)

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -80,6 +80,18 @@ def prune_pc_relate(
     print("=== Running PCA")
     union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pca_components)
     print("=== Calculating relatedness")
+    related_mt = related_mt.drop(#For some reason unrelated_mt doesn't have these
+        "AD",
+        "DP",
+        "GQ",
+        "MIN_DP",
+        "PGT",
+        "PID",
+        "PL",
+        "PS",
+        "SB",
+        "RGQ"
+    )
     pruned_mt = related_mt.union_cols(unrelated_mt)
     relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
@@ -173,6 +185,7 @@ def main():
     #filter matrix to have good variants
     filtered_mt = run_filtering(mt, **config["step2"]["filter_before_pruning"])
     filtered_mt.write(path_spark(config["step2"]["filtered_mt_outfile"]), overwrite=True)
+
     # run pcrelate
     related_samples_to_remove_ht, scores, unrelated_scores, loadings, relatedness_ht = prune_pc_relate(
         filtered_mt, config["step2"]["prune"], config["step2"]["king"], **config["step2"]["prune_pc_relate"]
@@ -180,9 +193,11 @@ def main():
     scores_file1 = config["step2"]["prune_pc_relate"]["scores_file"]
     scores_file2 = config["step2"]["prune_pc_relate"]["unrelated_samples_scores_file"]
     loadings_file = config["step2"]["prune_pc_relate"]["pca_loadings_file_pc_relate"]
+    
     scores.write(path_spark(scores_file1), overwrite=True)  # output
     unrelated_scores.write(path_spark(scores_file2), overwrite=True)  # output
     loadings.write(path_spark(loadings_file), overwrite=True)  # output
+    
     related_samples_to_remove_ht.write(
         path_spark(config["step2"]["prune_pc_relate"]["samples_to_remove_file"]), overwrite=True
     )

--- a/2-sample_qc/2-prune_related_samples.py
+++ b/2-sample_qc/2-prune_related_samples.py
@@ -5,100 +5,10 @@ import os
 from utils.utils import parse_config, path_local, path_spark
 import bokeh.plotting as bkplt
 import bokeh.layouts as bklayouts
-from wes_qc import hail_utils, hail_patches, constants, filtering
-from gnomad.sample_qc.ancestry import pc_project
-
-def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
-    """
-    Splits multiallelic sites and runs ld pruning
-    Filter to autosomes before LD pruning to decrease sample size - autosomes only wanted for later steps
-    :param MatrixTable mt: input MT containing variants to be pruned
-    :param dict config:
-    :return: Pruned MatrixTable
-    :rtype: hl.MatrixTable
-
-    `hl.ld_prune` returns a maximal subset of variants that are nearly uncorrelated within each window.
-    Requires the dataset to contain only diploid genotype calls and no multiallelic variants.
-    See also: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
-    """
-
-    print("=== Filtering to autosomes")
-    mt = mt.filter_rows(mt.locus.in_autosome())
-    print("=== Splitting multiallelic sites")
-    mt = hail_patches.split_multi_hts(
-        mt, recalculate_gq=False
-    )  # this shouldn't do anything as only biallelic sites are used
-    print("=== Performing LD pruning")
-    pruned_ht = hl.ld_prune(mt.GT, **ld_prune_args)
-    pruned_mt = mt.filter_rows(hl.is_defined(pruned_ht[mt.row_key]))
-    pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
-    return pruned_mt
-
-def run_filtering(mt: hl.MatrixTable, long_range_ld_file, call_rate_threshold, af_threshold, hwe_threshold) -> hl.MatrixTable:
-    print("=== Filtering")
-    filtered_mt = filtering.filter_matrix_for_ldprune(
-        mt, path_spark(long_range_ld_file), call_rate_threshold, af_threshold, hwe_threshold
-    )
-    return filtered_mt
-
-def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
-    print("=== LD pruning before KING")
-    pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
-    pruned_mt.write(path_spark(prune_args["pruned_mt_file"]), overwrite=True)
-    print("=== Running KING")
-    king_mt = hl.king(pruned_mt.GT)
-    king_ht=king_mt.entries()
-    king_ht.write(path_spark(king_args["king_output_file"]), overwrite=True)
-    related_pairs_ht = king_ht.filter((king_ht.phi > king_args["kinship_threshold"]) & (king_ht.s_1!=king_ht.s))
-    print("=== Identifying related samples")
-    samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
-    unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
-    related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
-    print("=== LD pruning unrelated samples")
-    pruned_unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
-    pruned_unrelated_mt.write(path_spark(king_args["unrelated_king_file"]), overwrite=True)
-    related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
-    related_mt.write(path_spark(king_args["related_king_file"]), overwrite=True)
-    return related_mt, pruned_unrelated_mt
-
-def run_pc_project(mt_ref, mt_study, pca_components):
-    print("=== Running PCA")
-    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
-    pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()
-    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
-    print("=== Running PC projection")
-    projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
-    union_pca_scores = pca_scores.union(projection_pca_scores)
-
-    return union_pca_scores, pca_scores, pca_loadings
-
-def prune_pc_relate(
-    mt: hl.MatrixTable, prune_args: dict, king_args: dict, pca_components: int, pc_relate_args: dict, relatedness_column: str, relatedness_threshold: float, **kwargs
-) -> (hl.Table, hl.Table, hl.Table, hl.Table, hl.Table):
-    print("=== Running KING")
-    related_mt, unrelated_mt = run_king(mt, king_args, prune_args)
-    print("=== Running PCA")
-    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pca_components)
-    print("=== Calculating relatedness")
-    related_mt = related_mt.drop(#For some reason unrelated_mt doesn't have these
-        "AD",
-        "DP",
-        "GQ",
-        "MIN_DP",
-        "PGT",
-        "PID",
-        "PL",
-        "PS",
-        "SB",
-        "RGQ"
-    )
-    pruned_mt = related_mt.union_cols(unrelated_mt)
-    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_args)
-    # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
-    pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)
-    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
-    return related_samples_to_remove, union_pca_scores, pca_scores, pca_loadings, relatedness_ht
-
+from wes_qc.pca_utils import prune_mt, run_pc_project
+from wes_qc.compute_relatedness import prune_pc_relate
+from wes_qc.filtering import filter_matrix_for_ldprune
+from wes_qc import hail_utils, constants, filtering
 
 def plot_relatedness(
     relatedness_ht: hl.Table, relatedness_plotfile: str, text_size=constants.plots_text_size, **kwargs
@@ -115,7 +25,6 @@ def plot_relatedness(
     bkplt.output_file(relatedness_plotfile)
     bkplt.save(layout)
 
-
 # TODO: How is this step different from 2-sample_qc/3-population_pca_prediction.py/run_pca()? Only PCA plotting?
 def run_population_pca(
     filtered_mt: hl.MatrixTable,
@@ -124,6 +33,7 @@ def run_population_pca(
 #    plink_outfile,
     pca_components,
     plot_outfile,
+    pruned_unrelated_pcrelate_file: str,
     **kwargs,
 ) -> (hl.MatrixTable, hl.Table, hl.Table):
     """
@@ -143,7 +53,7 @@ def run_population_pca(
     #hl.export_plink(dataset=plink_mt, output=path_spark(plink_outfile), fam_id=plink_mt.uid, ind_id=plink_mt.uid)
     print("=== Running LD pruning before PCA")
     unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
-    unrelated_mt.write(path_spark(prune_args["pruned_unrelated_pcrelate_file"]), overwrite=True)
+    unrelated_mt=unrelated_mt.checkpoint(path_spark(pruned_unrelated_pcrelate_file), overwrite=True)
     related_mt = related_mt.semi_join_rows(unrelated_mt.rows())
 
     union_pca_scores, pca_scores, pca_loadings=run_pc_project(unrelated_mt, related_mt, pca_components)
@@ -169,7 +79,7 @@ def main():
     mt_infile = config["step2"]["impute_sex"]["sex_mt_outfile"]
 
     # = STEP OUTPUTS = #
-    mtoutfile = config["step2"]["prune"]["pruned_mt_file"]
+    mtoutfile = config["step2"]["prune_params"]["pruned_mt_file"]
 
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
@@ -183,32 +93,25 @@ def main():
     #removing control samples
     mt= filtering.remove_samples(mt, control_list)
     #filter matrix to have good variants
-    filtered_mt = run_filtering(mt, **config["step2"]["filter_before_pruning"])
+    filtered_mt = filter_matrix_for_ldprune(mt, config["step2"]["long_range_ld_file"], **config["step2"]["filter_params"])
     filtered_mt.write(path_spark(config["step2"]["filtered_mt_outfile"]), overwrite=True)
 
     # run pcrelate
-    related_samples_to_remove_ht, scores, unrelated_scores, loadings, relatedness_ht = prune_pc_relate(
-        filtered_mt, config["step2"]["prune"], config["step2"]["king"], **config["step2"]["prune_pc_relate"]
+    related_samples_to_remove_ht, relatedness_ht = prune_pc_relate(
+        filtered_mt, config["step2"]["prune_params"], config["step2"]["king_params"], config["step2"]["pc_relate_params"], "study"
     )
-    scores_file1 = config["step2"]["prune_pc_relate"]["scores_file"]
-    scores_file2 = config["step2"]["prune_pc_relate"]["unrelated_samples_scores_file"]
-    loadings_file = config["step2"]["prune_pc_relate"]["pca_loadings_file_pc_relate"]
-    
-    scores.write(path_spark(scores_file1), overwrite=True)  # output
-    unrelated_scores.write(path_spark(scores_file2), overwrite=True)  # output
-    loadings.write(path_spark(loadings_file), overwrite=True)  # output
     
     related_samples_to_remove_ht.write(
-        path_spark(config["step2"]["prune_pc_relate"]["samples_to_remove_file"]), overwrite=True
+        path_spark(config["step2"]["relatedness_output"]["samples_to_remove_file"]), overwrite=True
     )
-    related_samples_to_remove_ht.export(path_spark(config["step2"]["prune_pc_relate"]["samples_to_remove_tsv"]))
-    relatedness_ht.export(path_spark(config["step2"]["prune_pc_relate"]["relatedness_outfile"]))
+    related_samples_to_remove_ht.export(path_spark(config["step2"]["relatedness_output"]["samples_to_remove_tsv"]))
+    relatedness_ht.export(path_spark(config["step2"]["relatedness_output"]["relatedness_outfile"]))
 
     # plot relatedness
-    plot_relatedness(relatedness_ht, **config["step2"]["prune_pc_relate"])
+    plot_relatedness(relatedness_ht, **config["step2"]["relatedness_output"]["relatedness_plotfile"])
     # run PCA
     pca_mt, union_pca_scores, pca_scores, pca_loadings = run_population_pca(
-        filtered_mt, related_samples_to_remove_ht, config["step2"]["prune"], **config["step2"]["prune_plot_pca"]
+        filtered_mt, related_samples_to_remove_ht, config["step2"]["prune_params"], **config["step2"]["prune_plot_pca"]
     )
     pca_mt.write(path_spark(config["step2"]["prune_plot_pca"]["pca_mt_file"]), overwrite=True)
     union_pca_scores.write(path_spark(config["step2"]["prune_plot_pca"]["union_pca_scores_file"]), overwrite=True)

--- a/2-sample_qc/3-population_pca_prediction.py
+++ b/2-sample_qc/3-population_pca_prediction.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import hail as hl
 from gnomad.sample_qc.ancestry import assign_population_pcs, pc_project
 
+from wes_qc.pca_utils import prune_mt, run_pc_project
 from wes_qc.hail_utils import path_local, path_spark
 from utils.utils import parse_config
 from wes_qc import hail_utils, filtering, visualize
@@ -14,7 +15,7 @@ def merge_1kg_and_ldprune(
     mt_filtered: hl.MatrixTable,
     kg_mt: hl.MatrixTable,
     pruned_mt_outfile: str,
-    r2_threshold: float,
+    ld_prune_args: dict,
     **kwargs,
 ) -> hl.MatrixTable:
     """
@@ -50,9 +51,7 @@ def merge_1kg_and_ldprune(
     kg_mt = kg_mt.semi_join_rows(mt_filtered.rows())
 
     # prunning of the linked Variants in kg_mt
-    pruned_ht = hl.ld_prune(kg_mt.GT, r2=r2_threshold)
-    pruned_mt = kg_mt.filter_rows(hl.is_defined(pruned_ht[kg_mt.row_key]))
-    pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
+    pruned_mt=prune_mt(kg_mt, ld_prune_args)
     pruned_mt = pruned_mt.checkpoint(pruned_mt_outfile, overwrite=True)
 
     # merging matrices
@@ -76,24 +75,13 @@ def pop_pca(
     mt_kg = mt.filter_cols(hl.is_defined(mt.known_pop))  # The golden source 1000G with known population
     mt_study = mt.filter_cols(hl.is_missing(mt.known_pop))
     # PCA for golden source 1000 Genomes
-    pca_1kg_evals, pca_1kg_scores, pca_1kg_loadings = hl.hwe_normalized_pca(
-        mt_kg.GT, k=pca_components, compute_loadings=True
-    )
-    pca_1kg_scores = pca_1kg_scores.annotate(known_pop=mt_kg.cols()[pca_1kg_scores.s].known_pop)
-    pca_af_ht = mt_kg.annotate_rows(pca_af=hl.agg.mean(mt_kg.GT.n_alt_alleles()) / 2).rows()
-    pca_1kg_loadings = pca_1kg_loadings.annotate(pca_af=pca_af_ht[pca_1kg_loadings.key].pca_af)
+    union_pca_scores, pca_1kg_scores, pca_1kg_loadings, pca_1kg_evals = run_pc_project(mt_kg, mt_study, pca_components)
 
+    pca_1kg_scores = pca_1kg_scores.annotate(known_pop=mt_kg.cols()[pca_1kg_scores.s].known_pop)
+    union_pca_scores = union_pca_scores.annotate(known_pop=mt.cols()[union_pca_scores.s].known_pop)
     with open(pca_1kg_evals_file, "w") as f:
         for val in pca_1kg_evals:
             f.write(str(val) + "\n")
-
-    pca_1kg_scores_nopop = pca_1kg_scores.drop(pca_1kg_scores.known_pop)
-
-    # projection of samples on precomputed PCs and combining of two PCA_scores tables
-    print("=== Projecting PCA scores to the cohort samples ===")
-    projection_pca_scores = pc_project(mt_study, pca_1kg_loadings, loading_location="loadings", af_location="pca_af")
-    union_pca_scores = pca_1kg_scores_nopop.union(projection_pca_scores)
-    union_pca_scores = union_pca_scores.annotate(known_pop=mt.cols()[union_pca_scores.s].known_pop)
 
     return pca_1kg_scores, pca_1kg_loadings, union_pca_scores
 

--- a/2-sample_qc/3-population_pca_prediction.py
+++ b/2-sample_qc/3-population_pca_prediction.py
@@ -11,14 +11,10 @@ from wes_qc import hail_utils, filtering, visualize
 
 
 def merge_1kg_and_ldprune(
-    mt: hl.MatrixTable,
+    mt_filtered: hl.MatrixTable,
     kg_mt: hl.MatrixTable,
-    long_range_ld_file: str,
     pruned_mt_outfile: str,
     r2_threshold: float,
-    call_rate_threshold: float,
-    af_threshold: float,
-    hwe_threshold: float,
     **kwargs,
 ) -> hl.MatrixTable:
     """
@@ -32,11 +28,6 @@ def merge_1kg_and_ldprune(
     :param af_threshold: Allele frequency threshold for filtering
     :param hwe_threshold: Hardy-Weinberg equilibrium threshold for filtering
     """
-
-    # filter sample matrix
-    mt_filtered = filtering.filter_matrix_for_ldprune(
-        mt, path_spark(long_range_ld_file), call_rate_threshold, af_threshold, hwe_threshold
-    )
 
     # removing and adding needed entries to replicate filtered_mt_file structure
     mt_filtered = mt_filtered.drop(
@@ -172,7 +163,8 @@ def main():
     control_list=config["general"]["metadata"]["control_samples"]
 
     # = STEP DEPENDENCIES = #
-    mtfile = path_spark(config["step2"]["impute_sex"]["sex_mt_outfile"])
+    #mtfile = path_spark(config["step2"]["impute_sex"]["sex_mt_outfile"])
+    mtfile = path_spark(config["step2"]["filtered_mt_outfile"])
     kg_mt_file = path_spark(config["step0"]["create_1kg_mt"]["kg_out_mt"])
     kg_pop_file = path_spark(config["step0"]["create_1kg_mt"]["kg_pop_file"])
 
@@ -192,8 +184,6 @@ def main():
 
     if args.merge_and_ldprune:
         mt = hl.read_matrix_table(mtfile)
-        #removing controll samples
-        mt= filtering.remove_samples(mt, control_list)
         kg_mt = hl.read_matrix_table(kg_mt_file)
         pruned_mt = merge_1kg_and_ldprune(mt, kg_mt, **config["step2"]["merge_1kg_and_ldprune"])
         pruned_mt.write(merged_mt_file, overwrite=True)

--- a/2-sample_qc/3-population_pca_prediction.py
+++ b/2-sample_qc/3-population_pca_prediction.py
@@ -14,7 +14,7 @@ def merge_1kg_and_ldprune(
     mt: hl.MatrixTable,
     kg_mt: hl.MatrixTable,
     long_range_ld_file: str,
-    merged_filtered_mt_outfile: str,
+    pruned_mt_outfile: str,
     r2_threshold: float,
     call_rate_threshold: float,
     af_threshold: float,
@@ -26,7 +26,7 @@ def merge_1kg_and_ldprune(
     :param mt: input matrix table
     :param kg_mt: 1kg matrix table
     :param long_range_ld_file: Long range LD file
-    :param merged_filtered_mt_outfile: Merged and filtered matrix output file
+    :param pruned_mt_outfile: pruned reference matrix output file
     :param r2_threshold: Correlation threshold for LD pruning
     :param call_rate_threshold: Call rate threshold for filtering
     :param af_threshold: Allele frequency threshold for filtering
@@ -54,17 +54,21 @@ def merge_1kg_and_ldprune(
     )  # Dropping row fields that are not present in the 1kg matrix
     mt_filtered = mt_filtered.select_cols()  # dropping all column fields
     mt_filtered = mt_filtered.annotate_cols(known_pop=hl.missing(hl.tstr))
-    # merging matrices
-    mt_merged = mt_filtered.union_cols(kg_mt)
-    # saving the merged matrix
-    mt_merged = mt_merged.checkpoint(merged_filtered_mt_outfile, overwrite=True)
+    # keeping shared variants
+    mt_filtered = mt_filtered.semi_join_rows(kg_mt.rows())
+    kg_mt = kg_mt.semi_join_rows(mt_filtered.rows())
 
-    # prunning of the linked Variants
-    pruned_ht = hl.ld_prune(mt_merged.GT, r2=r2_threshold)
-    pruned_mt = mt_merged.filter_rows(hl.is_defined(pruned_ht[mt_merged.row_key]))
+    # prunning of the linked Variants in kg_mt
+    pruned_ht = hl.ld_prune(kg_mt.GT, r2=r2_threshold)
+    pruned_mt = kg_mt.filter_rows(hl.is_defined(pruned_ht[kg_mt.row_key]))
     pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
+    pruned_mt = pruned_mt.checkpoint(pruned_mt_outfile, overwrite=True)
 
-    return pruned_mt
+    # merging matrices
+    mt_merged = mt_filtered.union_cols(pruned_mt)
+    # saving the merged matrix
+
+    return mt_merged
 
 
 def pop_pca(
@@ -173,7 +177,7 @@ def main():
     kg_pop_file = path_spark(config["step0"]["create_1kg_mt"]["kg_pop_file"])
 
     # = STEP OUTPUTS = #
-    pruned_mt_file = path_spark(config["step2"]["merge_1kg_and_ldprune"]["filtered_and_pruned_mt_outfile"])
+    merged_mt_file = path_spark(config["step2"]["merge_1kg_and_ldprune"]["pruned_and_merged_mt_outfile"])
     pca_1kg_scores_file = path_spark(config["step2"]["pop_pca"]["pca_1kg_scores_file"])
     pca_1kg_loadings_file = path_spark(config["step2"]["pop_pca"]["pca_1kg_loadings_file"])
     pca_union_scores_file = path_spark(config["step2"]["pop_pca"]["pca_union_scores_file"])
@@ -192,11 +196,11 @@ def main():
         mt= filtering.remove_samples(mt, control_list)
         kg_mt = hl.read_matrix_table(kg_mt_file)
         pruned_mt = merge_1kg_and_ldprune(mt, kg_mt, **config["step2"]["merge_1kg_and_ldprune"])
-        pruned_mt.write(pruned_mt_file, overwrite=True)
+        pruned_mt.write(merged_mt_file, overwrite=True)
 
     # run pca
     if args.pca:
-        filtered_mt = hl.read_matrix_table(pruned_mt_file)
+        filtered_mt = hl.read_matrix_table(merged_mt_file)
         pca_1kg_scores, pca_1kg_loadings, union_PCA_scores = pop_pca(filtered_mt, **config["step2"]["pop_pca"])
         pca_1kg_scores.write(pca_1kg_scores_file, overwrite=True)
         pca_1kg_loadings.write(pca_1kg_loadings_file, overwrite=True)

--- a/2-sample_qc/4-find_population_outliers.py
+++ b/2-sample_qc/4-find_population_outliers.py
@@ -853,7 +853,7 @@ def main():
 
     # = STEP PARAMETERS = #
     runmode=config["step2"]["stratified_sample_qc"]["sample_qc_method"]
-    control_list=config["step2"]["general"]["metadata"]["control_samples"]
+    control_list=config["general"]["metadata"]["control_samples"]
     if control_list is None:
         control_list=[]
 

--- a/3-variant_qc/5-annotate_ht_after_rf.py
+++ b/3-variant_qc/5-annotate_ht_after_rf.py
@@ -14,45 +14,40 @@ def add_cq_annotation(ht: hl.Table, synonymous_file: str) -> hl.Table:
     ;param str synonymous_file: text file containing synonymous variants
     ;param str ht_cq_fle: Output hail table file annotated with synonymous variants
     """
-    if pedfile is not None:
-        # DEBUG: test if file:// prefix is needed for this function
-        synonymous_ht = hl.import_table(
-            path_spark(synonymous_file),
-            types={"f0": "str", "f1": "int32", "f2": "str", "f3": "str", "f4": "str", "f6": "str"},
-            no_header=True,
-        )
-        synonymous_ht = synonymous_ht.annotate(chr=synonymous_ht.f0)
-        synonymous_ht = synonymous_ht.annotate(pos=synonymous_ht.f1)
-        synonymous_ht = synonymous_ht.annotate(rs=synonymous_ht.f2)
-        synonymous_ht = synonymous_ht.annotate(ref=synonymous_ht.f3)
-        synonymous_ht = synonymous_ht.annotate(alt=synonymous_ht.f4)
-        synonymous_ht = synonymous_ht.annotate(consequence=synonymous_ht.f6)
+    # DEBUG: test if file:// prefix is needed for this function
+    synonymous_ht = hl.import_table(
+        path_spark(synonymous_file),
+        types={"f0": "str", "f1": "int32", "f2": "str", "f3": "str", "f4": "str", "f6": "str"},
+        no_header=True,
+    )
+    synonymous_ht = synonymous_ht.annotate(chr=synonymous_ht.f0)
+    synonymous_ht = synonymous_ht.annotate(pos=synonymous_ht.f1)
+    synonymous_ht = synonymous_ht.annotate(rs=synonymous_ht.f2)
+    synonymous_ht = synonymous_ht.annotate(ref=synonymous_ht.f3)
+    synonymous_ht = synonymous_ht.annotate(alt=synonymous_ht.f4)
+    synonymous_ht = synonymous_ht.annotate(consequence=synonymous_ht.f6)
 
-        synonymous_ht = synonymous_ht.filter(synonymous_ht.consequence == "synonymous_variant")
+    synonymous_ht = synonymous_ht.filter(synonymous_ht.consequence == "synonymous_variant")
 
-        synonymous_ht = synonymous_ht.key_by(
-            locus=hl.locus(synonymous_ht.chr, synonymous_ht.pos), alleles=[synonymous_ht.ref, synonymous_ht.alt]
-        )
-        synonymous_ht = synonymous_ht.drop(
-            synonymous_ht.f0,
-            synonymous_ht.f1,
-            synonymous_ht.f2,
-            synonymous_ht.f3,
-            synonymous_ht.f4,
-            synonymous_ht.f6,
-            synonymous_ht.chr,
-            synonymous_ht.pos,
-            synonymous_ht.ref,
-            synonymous_ht.alt,
-        )
-        synonymous_ht = synonymous_ht.key_by(synonymous_ht.locus, synonymous_ht.alleles)
+    synonymous_ht = synonymous_ht.key_by(
+        locus=hl.locus(synonymous_ht.chr, synonymous_ht.pos), alleles=[synonymous_ht.ref, synonymous_ht.alt]
+    )
+    synonymous_ht = synonymous_ht.drop(
+        synonymous_ht.f0,
+        synonymous_ht.f1,
+        synonymous_ht.f2,
+        synonymous_ht.f3,
+        synonymous_ht.f4,
+        synonymous_ht.f6,
+        synonymous_ht.chr,
+        synonymous_ht.pos,
+        synonymous_ht.ref,
+        synonymous_ht.alt,
+    )
+    synonymous_ht = synonymous_ht.key_by(synonymous_ht.locus, synonymous_ht.alleles)
 
-        ht_cq = ht.annotate(consequence=synonymous_ht[ht.key].consequence)
-    else:
-        print("=== No pedigree data found: skipping synonymous variant annotation ===")
-        ht = ht.annotate(consequence=hl.missing(hl.tstr))
+    ht_cq = ht.annotate(consequence=synonymous_ht[ht.key].consequence)
     return ht_cq
-
 
 def dnm_and_family_annotation_with_missing(ht_cq: hl.Table) -> hl.Table:
     """
@@ -154,7 +149,6 @@ def dnm_and_family_annotation_with_missing(ht_cq: hl.Table) -> hl.Table:
 
     return ht_cq
 
-
 def dnm_and_family_annotation_with_tables(
     ht_cq: hl.Table, dnm_htfile: str, fam_stats_htfile: str, trio_stats_htfile: str
 ):
@@ -174,93 +168,74 @@ def dnm_and_family_annotation_with_tables(
 
     return ht_cq
 
-
-def dnm_and_family_annotation(
-    ht: hl.Table, dnm_htfile: str, fam_stats_htfile: str, trio_stats_htfile: str, pedfile: str
-) -> hl.Table:
-    if pedfile is not None:
-        # annotate with family stats and DNMs
-        print("=== Annotating with family stats and DNMs ===")
-        ht = dnm_and_family_annotation_with_tables(ht, dnm_htfile, fam_stats_htfile, trio_stats_htfile)
-    else:
-        print("=== No pedigree data found: annotating with missing family stats and DNMs ===")
-        ht = dnm_and_family_annotation_with_missing(ht)
-    return ht
-
-
 # TODO: To messy - a good candidate for refactoring
 def count_trans_untransmitted_singletons(mt_trios: Optional[hl.MatrixTable], ht: hl.Table) -> hl.Table:
     """
     Count untransmitted and transmitted singletons
     """
-    if mt_trios is not None:
-        # Filtering trios matrixtable
-        mt_trios = mt_trios.annotate_rows(consequence=ht[mt_trios.row_key].consequence)
+    # Filtering trios matrixtable
+    mt_trios = mt_trios.annotate_rows(consequence=ht[mt_trios.row_key].consequence)
 
-        # TODO: there is a save step here in Pavlos file, is it needed?
-        # mt_filtered = mt_trios.filter_rows((mt_trios.variant_qc.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant"))
-        # mt_filtered = mt_trios.filter_entries((mt_trios.variant_qc.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant"))
-        # TODO: unused step - was not commented out - probably incorrect
-        # mt_filtered = mt_trios.filter_rows(
-        #     (mt_trios.varqc_trios.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant")
-        # )
+    # TODO: there is a save step here in Pavlos file, is it needed?
+    # mt_filtered = mt_trios.filter_rows((mt_trios.variant_qc.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant"))
+    # mt_filtered = mt_trios.filter_entries((mt_trios.variant_qc.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant"))
+    # TODO: unused step - was not commented out - probably incorrect
+    # mt_filtered = mt_trios.filter_rows(
+    #     (mt_trios.varqc_trios.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant")
+    # )
 
-        mt_filtered = mt_trios.filter_entries(
-            (mt_trios.varqc_trios.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant")
+    mt_filtered = mt_trios.filter_entries(
+        (mt_trios.varqc_trios.AC[1] <= 2) & (mt_trios.consequence == "synonymous_variant")
+    )
+
+    mt_trans = mt_filtered.filter_entries(mt_filtered.varqc_trios.AC[1] == 2)
+    mt_untrans = mt_filtered.filter_entries(mt_filtered.varqc_trios.AC[1] == 1)
+
+    mt_trans_count = mt_trans.group_cols_by(mt_trans.id).aggregate(
+        transmitted_singletons_count=hl.agg.count_where(
+            # (mt_trans.info.AC[0] == 2) &
+            (mt_trans.proband_entry.GT.is_non_ref())
+            & ((mt_trans.father_entry.GT.is_non_ref()) | (mt_trans.mother_entry.GT.is_non_ref()))
         )
+    )
 
-        mt_trans = mt_filtered.filter_entries(mt_filtered.varqc_trios.AC[1] == 2)
-        mt_untrans = mt_filtered.filter_entries(mt_filtered.varqc_trios.AC[1] == 1)
+    total_transmitted_singletons = mt_trans_count.aggregate_entries(
+        hl.agg.count_where(mt_trans_count.transmitted_singletons_count > 0)
+    )
 
-        mt_trans_count = mt_trans.group_cols_by(mt_trans.id).aggregate(
-            transmitted_singletons_count=hl.agg.count_where(
-                # (mt_trans.info.AC[0] == 2) &
-                (mt_trans.proband_entry.GT.is_non_ref())
-                & ((mt_trans.father_entry.GT.is_non_ref()) | (mt_trans.mother_entry.GT.is_non_ref()))
-            )
+    mt_untrans_count = mt_untrans.group_cols_by(mt_untrans.id).aggregate(
+        untransmitted_singletons_count=hl.agg.count_where(
+            # (mt_untrans.info.AC[0] == 1) &
+            (mt_untrans.proband_entry.GT.is_hom_ref())
+            & ((mt_untrans.father_entry.GT.is_non_ref()) | (mt_untrans.mother_entry.GT.is_non_ref()))
         )
+    )
+    total_untransmitted_singletons = mt_untrans_count.aggregate_entries(
+        hl.agg.count_where(mt_untrans_count.untransmitted_singletons_count > 0)
+    )
 
-        total_transmitted_singletons = mt_trans_count.aggregate_entries(
-            hl.agg.count_where(mt_trans_count.transmitted_singletons_count > 0)
-        )
+    print(f"\nTransmitted singletons:{total_transmitted_singletons}\n")
+    print(f"\nUntransmitted singletons:{total_untransmitted_singletons}\n")
 
-        mt_untrans_count = mt_untrans.group_cols_by(mt_untrans.id).aggregate(
-            untransmitted_singletons_count=hl.agg.count_where(
-                # (mt_untrans.info.AC[0] == 1) &
-                (mt_untrans.proband_entry.GT.is_hom_ref())
-                & ((mt_untrans.father_entry.GT.is_non_ref()) | (mt_untrans.mother_entry.GT.is_non_ref()))
-            )
-        )
-        total_untransmitted_singletons = mt_untrans_count.aggregate_entries(
-            hl.agg.count_where(mt_untrans_count.untransmitted_singletons_count > 0)
-        )
+    if total_untransmitted_singletons > 0:
+        ratio_transmitted_untransmitted = total_transmitted_singletons / total_untransmitted_singletons
+        print(f"\nTrans/Untrans ratio:{ratio_transmitted_untransmitted}\n")
+    mt2 = mt_trans_count.annotate_rows(
+        variant_transmitted_singletons=hl.agg.count_where(mt_trans_count.transmitted_singletons_count == 1)
+    )
+    mt2.variant_transmitted_singletons.summarize()
 
-        print(f"\nTransmitted singletons:{total_transmitted_singletons}\n")
-        print(f"\nUntransmitted singletons:{total_untransmitted_singletons}\n")
+    mt3 = mt_untrans_count.annotate_rows(
+        variant_untransmitted_singletons=hl.agg.count_where(mt_untrans_count.untransmitted_singletons_count == 1)
+    )
+    mt3.variant_untransmitted_singletons.summarize()
 
-        if total_untransmitted_singletons > 0:
-            ratio_transmitted_untransmitted = total_transmitted_singletons / total_untransmitted_singletons
-            print(f"\nTrans/Untrans ratio:{ratio_transmitted_untransmitted}\n")
-        mt2 = mt_trans_count.annotate_rows(
-            variant_transmitted_singletons=hl.agg.count_where(mt_trans_count.transmitted_singletons_count == 1)
-        )
-        mt2.variant_transmitted_singletons.summarize()
+    variant_transmitted_annot = mt2.rows()[ht.key].variant_transmitted_singletons
+    ht = ht.annotate(variant_transmitted_singletons=variant_transmitted_annot)
 
-        mt3 = mt_untrans_count.annotate_rows(
-            variant_untransmitted_singletons=hl.agg.count_where(mt_untrans_count.untransmitted_singletons_count == 1)
-        )
-        mt3.variant_untransmitted_singletons.summarize()
-
-        variant_transmitted_annot = mt2.rows()[ht.key].variant_transmitted_singletons
-        ht = ht.annotate(variant_transmitted_singletons=variant_transmitted_annot)
-
-        variant_untransmitted_annot = mt3.rows()[ht.key].variant_untransmitted_singletons
-        ht = ht.annotate(variant_untransmitted_singletons=variant_untransmitted_annot)
-    else:
-        print("=== No pedigree data found: skipping transmitted/untransmitted calculations")
-        ht = ht.annotate(variant_transmitted_singletons=0, variant_untransmitted_singletons=0)
+    variant_untransmitted_annot = mt3.rows()[ht.key].variant_untransmitted_singletons
+    ht = ht.annotate(variant_untransmitted_singletons=variant_untransmitted_annot)
     return ht
-
 
 def transmitted_singleton_annotation(
     ht: hl.Table,
@@ -316,20 +291,21 @@ def main():
 
     # annotate with synonymous CQs
     ht = hl.read_table(path_spark(htfile))
-    if synonymous_file is not None:
-        ht = add_cq_annotation(ht, synonymous_file, pedfile)
+    if synonymous_file is not None and pedfile is not None:
+        ht = add_cq_annotation(ht, synonymous_file)
         ht.write(path_spark(ht_cq_file), overwrite=True)
+        # ht = hl.read_table(path_spark(ht_cq_file))
+        ht = dnm_and_family_annotation_with_tables(ht, dnm_htfile, fam_stats_htfile, trio_stats_htfile)
+        ht.write(path_spark(family_annot_htfile), overwrite=True)
+
+        # annotate with transmitted singletons
+        # ht = hl.read_table(path_spark(family_annot_htfile))
+        ht = transmitted_singleton_annotation(ht, trio_mtfile, pedfile)
     else:
-        print("=== No synonymous variant data found: skipping synonymous variant annotation ===")
+        print("=== No synonymous variant and/or pedigree data found: skipping transmitted/untransmitted singletons statistics calculations ===")
         ht = ht.annotate(consequence=hl.missing(hl.tstr))
-
-    # ht = hl.read_table(path_spark(ht_cq_file))
-    ht = dnm_and_family_annotation(ht, dnm_htfile, fam_stats_htfile, trio_stats_htfile, pedfile)
-    ht.write(path_spark(family_annot_htfile), overwrite=True)
-
-    # annotate with transmitted singletons
-    # ht = hl.read_table(path_spark(family_annot_htfile))
-    ht = transmitted_singleton_annotation(ht, trio_mtfile, pedfile)
+        ht = dnm_and_family_annotation_with_missing(ht)
+        ht = ht.annotate(variant_transmitted_singletons=0, variant_untransmitted_singletons=0)
     ht.write(path_spark(trans_sing_htfile), overwrite=True)
 
     # annotate with gnomad AF

--- a/3-variant_qc/5-annotate_ht_after_rf.py
+++ b/3-variant_qc/5-annotate_ht_after_rf.py
@@ -14,35 +14,43 @@ def add_cq_annotation(ht: hl.Table, synonymous_file: str) -> hl.Table:
     ;param str synonymous_file: text file containing synonymous variants
     ;param str ht_cq_fle: Output hail table file annotated with synonymous variants
     """
-    # DEBUG: test if file:// prefix is needed for this function
-    synonymous_ht = hl.import_table(
-        path_spark(synonymous_file),
-        types={"f0": "str", "f1": "int32", "f2": "str", "f3": "str", "f4": "str", "f5": "str"},
-        no_header=True,
-    )
-    synonymous_ht = synonymous_ht.annotate(chr=synonymous_ht.f0)
-    synonymous_ht = synonymous_ht.annotate(pos=synonymous_ht.f1)
-    synonymous_ht = synonymous_ht.annotate(rs=synonymous_ht.f2)
-    synonymous_ht = synonymous_ht.annotate(ref=synonymous_ht.f3)
-    synonymous_ht = synonymous_ht.annotate(alt=synonymous_ht.f4)
-    synonymous_ht = synonymous_ht.annotate(consequence=synonymous_ht.f5)
-    synonymous_ht = synonymous_ht.key_by(
-        locus=hl.locus(synonymous_ht.chr, synonymous_ht.pos), alleles=[synonymous_ht.ref, synonymous_ht.alt]
-    )
-    synonymous_ht = synonymous_ht.drop(
-        synonymous_ht.f0,
-        synonymous_ht.f1,
-        synonymous_ht.f2,
-        synonymous_ht.f3,
-        synonymous_ht.f4,
-        synonymous_ht.chr,
-        synonymous_ht.pos,
-        synonymous_ht.ref,
-        synonymous_ht.alt,
-    )
-    synonymous_ht = synonymous_ht.key_by(synonymous_ht.locus, synonymous_ht.alleles)
+    if pedfile is not None:
+        # DEBUG: test if file:// prefix is needed for this function
+        synonymous_ht = hl.import_table(
+            path_spark(synonymous_file),
+            types={"f0": "str", "f1": "int32", "f2": "str", "f3": "str", "f4": "str", "f6": "str"},
+            no_header=True,
+        )
+        synonymous_ht = synonymous_ht.annotate(chr=synonymous_ht.f0)
+        synonymous_ht = synonymous_ht.annotate(pos=synonymous_ht.f1)
+        synonymous_ht = synonymous_ht.annotate(rs=synonymous_ht.f2)
+        synonymous_ht = synonymous_ht.annotate(ref=synonymous_ht.f3)
+        synonymous_ht = synonymous_ht.annotate(alt=synonymous_ht.f4)
+        synonymous_ht = synonymous_ht.annotate(consequence=synonymous_ht.f6)
 
-    ht_cq = ht.annotate(consequence=synonymous_ht[ht.key].consequence)
+        synonymous_ht = synonymous_ht.filter(synonymous_ht.consequence == "synonymous_variant")
+
+        synonymous_ht = synonymous_ht.key_by(
+            locus=hl.locus(synonymous_ht.chr, synonymous_ht.pos), alleles=[synonymous_ht.ref, synonymous_ht.alt]
+        )
+        synonymous_ht = synonymous_ht.drop(
+            synonymous_ht.f0,
+            synonymous_ht.f1,
+            synonymous_ht.f2,
+            synonymous_ht.f3,
+            synonymous_ht.f4,
+            synonymous_ht.f6,
+            synonymous_ht.chr,
+            synonymous_ht.pos,
+            synonymous_ht.ref,
+            synonymous_ht.alt,
+        )
+        synonymous_ht = synonymous_ht.key_by(synonymous_ht.locus, synonymous_ht.alleles)
+
+        ht_cq = ht.annotate(consequence=synonymous_ht[ht.key].consequence)
+    else:
+        print("=== No pedigree data found: skipping synonymous variant annotation ===")
+        ht = ht.annotate(consequence=hl.missing(hl.tstr))
     return ht_cq
 
 
@@ -175,7 +183,7 @@ def dnm_and_family_annotation(
         print("=== Annotating with family stats and DNMs ===")
         ht = dnm_and_family_annotation_with_tables(ht, dnm_htfile, fam_stats_htfile, trio_stats_htfile)
     else:
-        print("=== No pedifree data found: annotating with missing family stats and DNMs ===")
+        print("=== No pedigree data found: annotating with missing family stats and DNMs ===")
         ht = dnm_and_family_annotation_with_missing(ht)
     return ht
 
@@ -249,7 +257,7 @@ def count_trans_untransmitted_singletons(mt_trios: Optional[hl.MatrixTable], ht:
         variant_untransmitted_annot = mt3.rows()[ht.key].variant_untransmitted_singletons
         ht = ht.annotate(variant_untransmitted_singletons=variant_untransmitted_annot)
     else:
-        print("=== No pedifree data found: skipping transmitted/untransmitted calculations")
+        print("=== No pedigree data found: skipping transmitted/untransmitted calculations")
         ht = ht.annotate(variant_transmitted_singletons=0, variant_untransmitted_singletons=0)
     return ht
 
@@ -285,7 +293,7 @@ def main():
     # = STEP PARAMETERS = #
     pedfile: str = config["step3"]["pedfile"]
     model_id: str = config["general"]["rf_model_id"]
-    synonymous_file: str = config["step3"]["add_cq_annotation"]["synonymous_file"]
+    synonymous_file: str = config["step3"]["add_cq_annotation"]["cqfile"]
     gnomad_htfile: str = config["step3"]["annotate_gnomad"]["gnomad_htfile"]
 
     # = STEP DEPENDENCIES = #
@@ -308,8 +316,12 @@ def main():
 
     # annotate with synonymous CQs
     ht = hl.read_table(path_spark(htfile))
-    ht = add_cq_annotation(ht, synonymous_file)
-    ht.write(path_spark(ht_cq_file), overwrite=True)
+    if synonymous_file is not None:
+        ht = add_cq_annotation(ht, synonymous_file, pedfile)
+        ht.write(path_spark(ht_cq_file), overwrite=True)
+    else:
+        print("=== No synonymous variant data found: skipping synonymous variant annotation ===")
+        ht = ht.annotate(consequence=hl.missing(hl.tstr))
 
     # ht = hl.read_table(path_spark(ht_cq_file))
     ht = dnm_and_family_annotation(ht, dnm_htfile, fam_stats_htfile, trio_stats_htfile, pedfile)

--- a/3-variant_qc/9-filter_mt_after_variant_qc.py
+++ b/3-variant_qc/9-filter_mt_after_variant_qc.py
@@ -22,7 +22,7 @@ def get_options():
 
 
 def annotate_mt_with_cq_rf_score_and_bin(
-    mtfile: str, rf_htfile: str, snv_threshold: int, indel_threshold: int, cqfile: str, filtered_mtfile: str
+    mtfile: str, rf_htfile: str, snv_threshold: int, indel_threshold: int, filtered_mtfile: str
 ):
     """
     Annotate matrixtable with RF score and bin then filter SNVs and indels according to threshold
@@ -42,23 +42,6 @@ def annotate_mt_with_cq_rf_score_and_bin(
     # annotate mt with score and bin
     mt = mt.annotate_rows(info=mt.info.annotate(rf_score=rf_ht[mt.row_key].score))
     mt = mt.annotate_rows(info=mt.info.annotate(rf_bin=rf_ht[mt.row_key].bin))
-
-    # annotate with VEP consequence
-    cq_ht = hl.import_table(
-        path_spark(cqfile),
-        types={"f0": "str", "f1": "int32", "f2": "str", "f3": "str", "f4": "str", "f5": "str"},
-        no_header=True,
-    )
-    cq_ht = cq_ht.annotate(chr=cq_ht.f0)
-    cq_ht = cq_ht.annotate(pos=cq_ht.f1)
-    cq_ht = cq_ht.annotate(rs=cq_ht.f2)
-    cq_ht = cq_ht.annotate(ref=cq_ht.f3)
-    cq_ht = cq_ht.annotate(alt=cq_ht.f4)
-    cq_ht = cq_ht.annotate(consequence=cq_ht.f5)
-    cq_ht = cq_ht.key_by(locus=hl.locus(cq_ht.chr, cq_ht.pos), alleles=[cq_ht.ref, cq_ht.alt])
-    cq_ht = cq_ht.drop(cq_ht.f0, cq_ht.f1, cq_ht.f2, cq_ht.f3, cq_ht.f4, cq_ht.chr, cq_ht.pos, cq_ht.ref, cq_ht.alt)
-    cq_ht = cq_ht.key_by(cq_ht.locus, cq_ht.alleles)
-    mt = mt.annotate_rows(info=mt.info.annotate(consequence=cq_ht[mt.row_key].consequence))
 
     # filter by SNV and indel thresholds
     mt_filtered = mt.filter_rows(
@@ -86,14 +69,13 @@ def main():
     rf_dir = path_spark(config["general"]["var_qc_rf_dir"])
     htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")
     mtfile = config["step3"]["annotate_mt_with_cq_rf_score_and_bin"]["mtfile"]
-    cqfile = config["step3"]["annotate_mt_with_cq_rf_score_and_bin"]["cqfile"]
 
     # = STEP OUTPUTS = #
     mtoutfile_after_varqc = config["step3"]["annotate_mt_with_cq_rf_score_and_bin"]["mtoutfile_after_varqc"]
 
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
-    annotate_mt_with_cq_rf_score_and_bin(mtfile, htfile, args.snv, args.indel, cqfile, mtoutfile_after_varqc)
+    annotate_mt_with_cq_rf_score_and_bin(mtfile, htfile, args.snv, args.indel, mtoutfile_after_varqc)
 
 
 if __name__ == "__main__":

--- a/3-variant_qc/9-filter_mt_after_variant_qc.py
+++ b/3-variant_qc/9-filter_mt_after_variant_qc.py
@@ -30,7 +30,6 @@ def annotate_mt_with_cq_rf_score_and_bin(
     :param str rf_htfile: random forest hail table file
     :param int snv_threshold: bin threshold for SNVs
     :param int indel_threshold: bin threshold for indels
-    :param str cqfile: File containing consequence annotation
     :param str filtered_mtfile: random forest score annotated mtfile
     """
     mt = hl.read_matrix_table(path_spark(mtfile))

--- a/4-genotype_qc/1-compare_hard_filter_combinations.py
+++ b/4-genotype_qc/1-compare_hard_filter_combinations.py
@@ -1019,7 +1019,7 @@ def main():
 
     # Files from VariantQC
     mtfile: str = config["step3"]["split_multi_and_var_qc"]["varqc_mtoutfile_split"]
-    cqfile: str = config["step3"]["add_cq_annotation"]["cqfile"]
+    cqfile: str = config["general"]["metadata"]["vep_consequences"]
     pedfile: str = config["step3"]["pedfile"]
     rf_htfile: str = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")
 

--- a/4-genotype_qc/1-compare_hard_filter_combinations.py
+++ b/4-genotype_qc/1-compare_hard_filter_combinations.py
@@ -35,7 +35,10 @@ def clean_mt(mt: hl.MatrixTable) -> hl.MatrixTable:
     Reduces matrixtable by cleaning all fields not required for hardfilter evaluation
     """
     mt = mt.select_entries(mt.GT, mt.HetAB, mt.DP, mt.GQ)
-    mt = mt.drop(mt.assigned_pop, *mt.row_value)
+    if "assigned_pop" in mt.col:
+        mt = mt.drop(mt.assigned_pop, *mt.row_value)
+    else:
+        mt = mt.drop(*mt.row_value)
     mt = mt.annotate_rows(info=hl.Struct())
     mt = mt.annotate_rows(
         type=hl.case()
@@ -74,7 +77,7 @@ def annotate_cq(mt: hl.MatrixTable, cqfile: str) -> hl.MatrixTable:
     :return: hl.MatrixTable
     """
     ht = hl.import_table(path_spark(cqfile), types={"f1": "int32"}, no_header=True)
-    ht = ht.rename({"f0": "chr", "f1": "pos", "f2": "rs", "f3": "ref", "f4": "alt", "f5": "consequence"})
+    ht = ht.rename({"f0": "chr", "f1": "pos", "f2": "rs", "f3": "ref", "f4": "alt", "f6": "consequence"})
     ht = ht.key_by(locus=hl.locus(ht.chr, ht.pos), alleles=[ht.ref, ht.alt])
     ht = ht.drop(ht.chr, ht.pos, ht.ref, ht.alt)
     mt = mt.annotate_rows(consequence=ht[mt.row_key].consequence)
@@ -172,6 +175,7 @@ def process_filter_combination(
     mtdir: str,
     giab_sample_id: Optional[str] = None,
     prec_recall_panel: Optional[hl.Table] = None,
+    csq_anntation_file: Optional[str] = None,
 ) -> EvaluationStepResults:
     """
     Process a single filter combination and return the variant counts and metrics.
@@ -212,7 +216,7 @@ def process_filter_combination(
         var_counts["mendelian_error_mean"], var_counts["mendelian_error_std"] = -1.0, -1.0
 
     # Counting transmitted/untransmitted ratio - for SNPs only
-    if var_type == "snv" and pedigree is not None:
+    if var_type == "snv" and pedigree is not None and csq_anntation_file is not None:
         # Extracting synonymous for transmitted/unstransmitted calculation
         mt_syn = mt_hard_filtered.filter_rows(mt_hard_filtered.consequence == "synonymous_variant")
         ratio = count_trans_untrans(mt_syn, pedigree)
@@ -238,6 +242,7 @@ def process_filter_combination(
                 ht_giab_dataset=ht_giab_dataset,
                 mtdir=mtdir,
                 prec_recall_panel=prec_recall_panel,
+                csq_anntation_file=csq_anntation_file
             )
             var_counts["prec"] = prec
             var_counts["recall"] = recall
@@ -285,6 +290,7 @@ def filter_and_count(
     mt: hl.MatrixTable,
     ht_giab_control: hl.Table,
     pedigree: Optional[hl.Pedigree],
+    cqfile: Optional[str],
     mtdir: str,
     var_type: str,
     hardfilter_combinations: dict[str, list[Union[int, float]]],
@@ -358,6 +364,7 @@ def filter_and_count(
             giab_sample_id=giab_sample_id,
             json_dump_folder=json_dump_folder,
             prec_recall_panel=prec_recall_panel,
+            csq_anntation_file=cqfile,
         )
         results[var_type][filter_name] = var_counts
 
@@ -402,6 +409,7 @@ def filter_and_count(
                             giab_sample_id=giab_sample_id,
                             json_dump_folder=json_dump_folder,
                             prec_recall_panel=prec_recall_panel,
+                            csq_anntation_file=cqfile,
                         )
 
                         results[var_type][filter_name] = var_counts
@@ -476,7 +484,7 @@ def apply_hard_filters(
 
 
 def count_prec_recall_indel(
-    ht_giab_control: hl.Table, ht_giab_dataset: hl.Table, mtdir: str, prec_recall_panel: Optional[hl.Table] = None
+    ht_giab_control: hl.Table, ht_giab_dataset: hl.Table, mtdir: str, prec_recall_panel: Optional[hl.Table] = None, csq_anntation_file: Optional[str] = None
 ) -> tuple:
     """
     Get precison/recall vs GIAB for indels
@@ -487,22 +495,26 @@ def count_prec_recall_indel(
 
     # Regular precision-recall for the full set of indels
     p, r = count_precision_recall(ht_giab_control, ht_giab_dataset_indels, prec_recall_panel)
+    if csq_anntation_file is not None:
+        # Precision/recall for FrameShift indels
+        ht_giab_control_frameshift = ht_giab_control.filter(ht_giab_control.consequence == "frameshift_variant")
+        ht_giab_dataset_frameshift = ht_giab_dataset_indels.filter(
+            ht_giab_dataset_indels.consequence == "frameshift_variant"
+        )
+        p_f, r_f = count_precision_recall(ht_giab_control_frameshift, ht_giab_dataset_frameshift, prec_recall_panel)
 
-    # Precision/recall for FrameShift indels
-    ht_giab_control_frameshift = ht_giab_control.filter(ht_giab_control.consequence == "frameshift_variant")
-    ht_giab_dataset_frameshift = ht_giab_dataset_indels.filter(
-        ht_giab_dataset_indels.consequence == "frameshift_variant"
-    )
-    p_f, r_f = count_precision_recall(ht_giab_control_frameshift, ht_giab_dataset_frameshift, prec_recall_panel)
-
-    # Precision/recall for In-Frame indels
-    inframe_cqs = ["inframe_deletion", "inframe_insertion"]
-    ht_giab_conrol_inframe = ht_giab_control.filter(hl.literal(inframe_cqs).contains(ht_giab_control.consequence))
-    ht_giab_dataset_inframe = ht_giab_dataset_indels.filter(
-        hl.literal(inframe_cqs).contains(ht_giab_dataset_indels.consequence)
-    )
-    p_if, r_if = count_precision_recall(ht_giab_conrol_inframe, ht_giab_dataset_inframe, prec_recall_panel)
-
+        # Precision/recall for In-Frame indels
+        inframe_cqs = ["inframe_deletion", "inframe_insertion"]
+        ht_giab_conrol_inframe = ht_giab_control.filter(hl.literal(inframe_cqs).contains(ht_giab_control.consequence))
+        ht_giab_dataset_inframe = ht_giab_dataset_indels.filter(
+            hl.literal(inframe_cqs).contains(ht_giab_dataset_indels.consequence)
+        )
+        p_if, r_if = count_precision_recall(ht_giab_conrol_inframe, ht_giab_dataset_inframe, prec_recall_panel)
+    else:
+        p_f = -1
+        r_f = -1
+        p_if = -1
+        r_if = -1
     return p, r, p_f, r_f, p_if, r_if
 
 
@@ -1003,7 +1015,7 @@ def main():
 
     # Files from VariantQC
     mtfile: str = config["step3"]["split_multi_and_var_qc"]["varqc_mtoutfile_split"]
-    cqfile: str = config["step3"]["annotate_mt_with_cq_rf_score_and_bin"]["cqfile"]
+    cqfile: str = config["step3"]["add_cq_annotation"]["cqfile"]
     pedfile: str = config["step3"]["pedfile"]
     rf_htfile: str = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")
 
@@ -1029,7 +1041,8 @@ def main():
 
         rf_ht = hl.read_table(path_spark(rf_htfile))
         mt_annot = annotate_with_rf(mt, rf_ht)
-        mt_annot = annotate_cq(mt_annot, cqfile)
+        if cqfile is not None:
+            mt_annot = annotate_cq(mt_annot, cqfile)
         mt_annot.write(path_spark(mt_annot_path), overwrite=True)
 
     ht_giab_control = hl.read_table(path_spark(giab_ht_file))
@@ -1043,6 +1056,7 @@ def main():
             mt,
             ht_giab_control,
             pedigree,
+            cqfile,
             mtdir=path_spark(hardfilter_evaluate_workdir),
             var_type="snv",
             prec_recall_panel=prec_recall_panel,
@@ -1063,6 +1077,7 @@ def main():
             mt,
             ht_giab_control,
             pedigree,
+            cqfile,
             mtdir=path_spark(hardfilter_evaluate_workdir),
             var_type="indel",
             prec_recall_panel=prec_recall_panel,

--- a/4-genotype_qc/2-apply_range_of_hard_filters.py
+++ b/4-genotype_qc/2-apply_range_of_hard_filters.py
@@ -102,7 +102,7 @@ def annotate_ac(mt: hl.MatrixTable, filter_name: str) -> hl.MatrixTable:
 
 
 # Build filter conditions for autosomes
-def build_autosomal_condition(hard_filters: dict, filter_level: str):
+def build_autosomal_condition(mt: hl.MatrixTable, hard_filters: dict, filter_level: str):
     """Build filtering condition for all chromosomes"""
     condition = (
         (hl.is_snp(mt.alleles[0], mt.alleles[1]))
@@ -127,7 +127,7 @@ def build_autosomal_condition(hard_filters: dict, filter_level: str):
     )
     return condition
 
-def build_sex_chr_condition(hard_filters: dict, filter_level: str):
+def build_sex_chr_condition(mt: hl.MatrixTable, hard_filters: dict, filter_level: str):
     """
     Build filtering condition using different thresholds for sex chromosomes
     For males on chrX non-PAR and chrY: exclude heterozygous calls
@@ -179,14 +179,14 @@ def apply_hard_filters(
 
     # Build final conditions combining autosomal and sex chromosome logic
     if diff_sex_chromosome_filter:
-        stringent_condition = build_sex_chr_condition(hard_filters, "stringent")
-        medium_condition = build_sex_chr_condition(hard_filters, "medium")
-        relaxed_condition = build_sex_chr_condition(hard_filters, "relaxed")
+        stringent_condition = build_sex_chr_condition(mt, hard_filters, "stringent")
+        medium_condition = build_sex_chr_condition(mt, hard_filters, "medium")
+        relaxed_condition = build_sex_chr_condition(mt, hard_filters, "relaxed")
     else:
         # Use standard filtering for all chromosomes
-        stringent_condition = build_autosomal_condition(hard_filters, "stringent")
-        medium_condition = build_autosomal_condition(hard_filters, "medium")
-        relaxed_condition = build_autosomal_condition(hard_filters, "relaxed")
+        stringent_condition = build_autosomal_condition(mt, hard_filters, "stringent")
+        medium_condition = build_autosomal_condition(mt, hard_filters, "medium")
+        relaxed_condition = build_autosomal_condition(mt, hard_filters, "relaxed")
     
     # Adding pass/fail tags to all genotypes
     mt = mt.annotate_entries(
@@ -293,7 +293,7 @@ def main():
     hard_filters = config["step4"]["apply_hard_filters"]["hard_filters"]
     
     # Get sex chromosome filtering flag from config (default to False if not present)
-    diff_sex_chromosome_filter = config["step4"]["apply_hard_filters"]["diff_sex_chromosome_filter"]
+    diff_sex_chromosome_filter = config["step4"]["apply_hard_filters"]["sex_chromosome_specific_filtering"]
 
     # = STEP DEPENDENCIES = #
     rf_dir = path_spark(
@@ -319,7 +319,7 @@ def main():
     print("=== Annotating mt with consequence, gene, rf bin ===")
     mt_annot = annotate_rf(mt, rf_htfile)
     if cqfile is not None:
-        mt_annot = annotate_ac(mt_annot, cqfile)
+        mt_annot = annotate_cq(mt_annot, cqfile)
     print("=== Applying hard filters ===")
     if diff_sex_chromosome_filter:
         print("=== Sex chromosome-specific filtering ENABLED ===")

--- a/4-genotype_qc/2-apply_range_of_hard_filters.py
+++ b/4-genotype_qc/2-apply_range_of_hard_filters.py
@@ -94,81 +94,93 @@ def annotate_ac(mt: hl.MatrixTable, filter_name: str) -> hl.MatrixTable:
     return mt
 
 
+# Build filter conditions for autosomes
+def build_autosomal_condition(hard_filters: dict, filter_level: str):
+    """Build filtering condition for all chromosomes"""
+    condition = (
+        (hl.is_snp(mt.alleles[0], mt.alleles[1]))
+        & (mt.info.rf_bin <= hard_filters["snp"][filter_level]["bin"])
+        & (mt.DP >= hard_filters["snp"][filter_level]["dp"])
+        & (mt.GQ >= hard_filters["snp"][filter_level]["gq"])
+        & (
+            (mt.GT.is_het() & (mt.HetAB >= hard_filters["snp"][filter_level]["ab"]))
+            | (mt.GT.is_hom_ref())
+            | (mt.GT.is_hom_var())
+        )
+    ) | (
+        (hl.is_indel(mt.alleles[0], mt.alleles[1]))
+        & (mt.info.rf_bin <= hard_filters["indel"][filter_level]["bin"])
+        & (mt.DP >= hard_filters["indel"][filter_level]["dp"])
+        & (mt.GQ >= hard_filters["indel"][filter_level]["gq"])
+        & (
+            (mt.GT.is_het() & (mt.HetAB >= hard_filters["indel"][filter_level]["ab"]))
+            | (mt.GT.is_hom_ref())
+            | (mt.GT.is_hom_var())
+        )
+    )
+    return condition
+
+def build_sex_chr_condition(hard_filters: dict, filter_level: str):
+    """
+    Build filtering condition using different thresholds for sex chromosomes
+    For males on chrX non-PAR and chrY: exclude heterozygous calls
+    For females on chrX: use standard filtering
+    """
+    condition = (
+        (hl.is_snp(mt.alleles[0], mt.alleles[1]))
+        & (mt.info.rf_bin <= hard_filters["snp"][filter_level]["bin"])
+        & (
+            ((mt.DP >= hard_filters["snp"][filter_level]["dp"]) & (mt.sex == 'female'))
+            | ((mt.DP >= hard_filters["snp"][filter_level]["dp"]) & (mt.sex == 'male') & mt.locus.in_autosome_or_par())
+            | ((mt.DP >= (hard_filters["snp"][filter_level]["dp"] / 2)) & (mt.sex == 'male') & (mt.locus.in_x_nonpar() | mt.locus.in_y_nonpar()))
+        )
+        & (mt.GQ >= hard_filters["snp"][filter_level]["gq"])
+        & (
+            (mt.GT.is_het() & (mt.HetAB >= hard_filters["snp"][filter_level]["ab"]))
+            | (mt.GT.is_hom_ref())
+            | (mt.GT.is_hom_var())
+        )
+    ) | (
+        (hl.is_indel(mt.alleles[0], mt.alleles[1]))
+        & (mt.info.rf_bin <= hard_filters["indel"][filter_level]["bin"])
+        & (
+            ((mt.DP >= hard_filters["indel"][filter_level]["dp"]) & (mt.sex == 'female'))
+            | ((mt.DP >= hard_filters["indel"][filter_level]["dp"]) & (mt.sex == 'male') & mt.locus.in_autosome_or_par())
+            | ((mt.DP >= (hard_filters["indel"][filter_level]["dp"] / 2)) & (mt.sex == 'male') & (mt.locus.in_x_nonpar() | mt.locus.in_y_nonpar()))
+        )
+        & (mt.GQ >= hard_filters["indel"][filter_level]["gq"])
+        & (
+            (mt.GT.is_het() & (mt.HetAB >= hard_filters["indel"][filter_level]["ab"]))
+            | (mt.GT.is_hom_ref())
+            | (mt.GT.is_hom_var())
+        )
+    )
+    return condition
+
 def apply_hard_filters(
-    mt: hl.MatrixTable, hard_filters: dict[str, dict[str, dict[str : Union[int, float]]]]
+    mt: hl.MatrixTable, 
+    hard_filters: dict[str, dict[str, dict[str, Union[int, float]]]],
+    diff_sex_chromosome_filter: bool = False
 ) -> hl.MatrixTable:
     """
     Apply hard filters and annotate missingness
     :param hl.MatrixTable mt: Input MatrixTable
     :param dict hard_filters: Filters to apply
+    :param bool diff_sex_chromosome_filter: If True, apply different filtering for sex chromosomes
     :return hl.MatrixTable:
     """
-    # Expressions for Pass/Fail conditions for individual genotypes -
-    stringent_condition = (
-        (hl.is_snp(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["snp"]["stringent"]["bin"])
-        & (mt.DP >= hard_filters["snp"]["stringent"]["dp"])
-        & (mt.GQ >= hard_filters["snp"]["stringent"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["snp"]["stringent"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    ) | (
-        (hl.is_indel(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["indel"]["stringent"]["bin"])
-        & (mt.DP >= hard_filters["indel"]["stringent"]["dp"])
-        & (mt.GQ >= hard_filters["indel"]["stringent"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["indel"]["stringent"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    )
 
-    medium_condition = (
-        (hl.is_snp(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["snp"]["medium"]["bin"])
-        & (mt.DP >= hard_filters["snp"]["medium"]["dp"])
-        & (mt.GQ >= hard_filters["snp"]["medium"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["snp"]["medium"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    ) | (
-        (hl.is_indel(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["indel"]["medium"]["bin"])
-        & (mt.DP >= hard_filters["indel"]["medium"]["dp"])
-        & (mt.GQ >= hard_filters["indel"]["medium"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["indel"]["medium"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    )
-
-    relaxed_condition = (
-        (hl.is_snp(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["snp"]["relaxed"]["bin"])
-        & (mt.DP >= hard_filters["snp"]["relaxed"]["dp"])
-        & (mt.GQ >= hard_filters["snp"]["relaxed"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["snp"]["relaxed"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    ) | (
-        (hl.is_indel(mt.alleles[0], mt.alleles[1]))
-        & (mt.info.rf_bin <= hard_filters["indel"]["relaxed"]["bin"])
-        & (mt.DP >= hard_filters["indel"]["relaxed"]["dp"])
-        & (mt.GQ >= hard_filters["indel"]["relaxed"]["gq"])
-        & (
-            (mt.GT.is_het() & (mt.HetAB >= hard_filters["indel"]["relaxed"]["ab"]))
-            | (mt.GT.is_hom_ref())
-            | (mt.GT.is_hom_var())
-        )
-    )
+    # Build final conditions combining autosomal and sex chromosome logic
+    if diff_sex_chromosome_filter:
+        stringent_condition = build_sex_chr_condition(hard_filters, "stringent")
+        medium_condition = build_sex_chr_condition(hard_filters, "medium")
+        relaxed_condition = build_sex_chr_condition(hard_filters, "relaxed")
+    else:
+        # Use standard filtering for all chromosomes
+        stringent_condition = build_autosomal_condition(hard_filters, "stringent")
+        medium_condition = build_autosomal_condition(hard_filters, "medium")
+        relaxed_condition = build_autosomal_condition(hard_filters, "relaxed")
+    
     # Adding pass/fail tags to all genotypes
     mt = mt.annotate_entries(
         stringent_filters=hl.if_else(stringent_condition, "Pass", "Fail"),
@@ -244,6 +256,25 @@ def apply_missingness(
 
     return mt
 
+def sex_annotation(mt: hl.MatrixTable, sex_metadata_file: str, **kwargs) -> hl.MatrixTable:
+    """
+    Annotates samples in the matrix-table with sex
+    """
+    metadata_ht = hl.import_table(path_spark(sex_metadata_file), delimiter="\t").key_by("sample_id")
+    metadata_ht = metadata_ht.transmute(self_reported_sex=metadata_ht.self_reported_sex.lower())
+    mt_sex_annotated = mt.annotate_cols(sex=metadata_ht[mt.s].self_reported_sex)
+
+    # Checking for the samples without self-reported sex
+    samples = mt_sex_annotated.cols()
+    samples_without_reported_sex = samples.filter(~hl.is_defined(samples.sex))
+    n_samples_no_reported_sex = samples_without_reported_sex.count()
+    if n_samples_no_reported_sex > 0:
+        print(f"=== WARNING: Detected {n_samples_no_reported_sex} samples without reported sex: ", end="")
+        print(" ".join(samples_without_reported_sex.s.collect()))
+    else:
+        print("=== OK: All samples are annotated with reported sex")
+
+    return mt_sex_annotated
 
 def main():
     # = STEP SETUP = #
@@ -253,6 +284,9 @@ def main():
     # = STEP PARAMETERS = #
     model_id = config["general"]["rf_model_id"]
     hard_filters = config["step4"]["apply_hard_filters"]["hard_filters"]
+    
+    # Get sex chromosome filtering flag from config (default to False if not present)
+    diff_sex_chromosome_filter = config["step4"]["apply_hard_filters"]["diff_sex_chromosome_filter"]
 
     # = STEP DEPENDENCIES = #
     rf_dir = path_spark(
@@ -260,7 +294,7 @@ def main():
     )  # TODO: use adapters inside the functions to enhance robustness
     mtfile = config["step4"]["annotate_cq_rf"]["mtfile"]
     cqfile = config["step4"]["annotate_cq_rf"]["cqfile"]
-
+    sex_annotation_file= config["step4"]["apply_hard_filters"]["sex_annotation_file"]
     # = STEP OUTPUTS = #
     mtfile_annot = config["step4"]["mtoutfile_annot"]
 
@@ -278,8 +312,11 @@ def main():
     print("=== Annotating mt with consequence, gene, rf bin ===")
     mt_annot = annotate_cq_rf(mt, rf_htfile, cqfile)
     print("=== Applying hard filters ===")
+    if diff_sex_chromosome_filter:
+        print("=== Sex chromosome-specific filtering ENABLED ===")
+        mt_annot=sex_annotation(mt_annot, path_spark(sex_annotation_file))
     # annotate with all combinations of filters (pass/fail) and add missingness
-    mt_annot = apply_hard_filters(mt_annot, hard_filters)
+    mt_annot = apply_hard_filters(mt_annot, hard_filters, diff_sex_chromosome_filter=diff_sex_chromosome_filter)
     mt_annot.write(path_spark(mtfile_annot), overwrite=True)
 
 

--- a/4-genotype_qc/2-apply_range_of_hard_filters.py
+++ b/4-genotype_qc/2-apply_range_of_hard_filters.py
@@ -21,13 +21,12 @@ def remove_samples(mt: hl.MatrixTable, exclude_file: str):
     return mt
 
 
-def annotate_cq_rf(mt: hl.MatrixTable, rf_htfile: str, cqfile: str) -> hl.MatrixTable:
+def annotate_rf(mt: hl.MatrixTable, rf_htfile: str, ) -> hl.MatrixTable:
     """
-    Annotate with RF bin, consequence, gene name, hgnc id, and pass/fail for 3 combinations of filters for SNPs,
+    Annotate with RF bin and pass/fail for 3 combinations of filters for SNPs,
     3 combinations of filters for indels and missingness for each set of filters
     :param hl.MatrixTable mtfile: Input matrixtable
     :param str rf_htfile: random forest hail table file
-    :param str cqfile: consequence file
     :return hl.matrixTable:
     """
     rf_ht = hl.read_table(path_spark(rf_htfile))
@@ -37,6 +36,15 @@ def annotate_cq_rf(mt: hl.MatrixTable, rf_htfile: str, cqfile: str) -> hl.Matrix
     mt = mt.annotate_rows(info=mt.info.annotate(rf_score=rf_ht[mt.row_key].score))
     mt = mt.annotate_rows(info=mt.info.annotate(rf_bin=rf_ht[mt.row_key].bin))
 
+    return mt
+
+def annotate_cq(mt: hl.MatrixTable, cqfile: str) -> hl.MatrixTable:
+    """
+    Annotate with consequence, gene name, and hgnc id
+    :param hl.MatrixTable mtfile: Input matrixtable
+    :param str cqfile: consequence file
+    :return hl.matrixTable:
+    """
     cq_ht = hl.import_table(
         path_spark(cqfile),
         types={
@@ -74,7 +82,6 @@ def annotate_cq_rf(mt: hl.MatrixTable, rf_htfile: str, cqfile: str) -> hl.Matrix
     )
 
     return mt
-
 
 def annotate_ac(mt: hl.MatrixTable, filter_name: str) -> hl.MatrixTable:
     assert filter_name in ("stringent", "medium", "relaxed")
@@ -310,7 +317,9 @@ def main():
 
     # annotate mt with consequence, gene, rf bin
     print("=== Annotating mt with consequence, gene, rf bin ===")
-    mt_annot = annotate_cq_rf(mt, rf_htfile, cqfile)
+    mt_annot = annotate_rf(mt, rf_htfile)
+    if cqfile is not None:
+        mt_annot = annotate_ac(mt_annot, cqfile)
     print("=== Applying hard filters ===")
     if diff_sex_chromosome_filter:
         print("=== Sex chromosome-specific filtering ENABLED ===")

--- a/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
+++ b/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
@@ -35,7 +35,8 @@ def export_vcfs(
             filter_metric = f"{filter_level}_{metric}"
             mt = mt.annotate_rows(info=mt.info.annotate(**{filter_metric: mt[filter_metric]}))
             mt = mt.drop(mt[filter_metric])
-
+    #remove variants if their relaxed_AC equals 0 after filtering
+    mt=mt.filter_rows(mt.info.relaxed_AC == [0], keep=False)
     mt = mt.drop(
         mt.a_index,
         mt.was_split,

--- a/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
+++ b/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
@@ -47,9 +47,10 @@ def export_vcfs(
         mt.medium_pass_count,
         mt.relaxed_pass_count,
         mt.adj,
-        mt.assigned_pop,
         mt.sum_AD,
     )
+    if "assigned_pop" in mt.col:
+        mt = mt.drop(mt.assigned_pop)
 
     # info for header
     stringent_filters = (

--- a/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
+++ b/4-genotype_qc/3a-export_vcfs_range_of_hard_filters.py
@@ -1,10 +1,12 @@
 # export to VCF after annotating with a range of hard filters
+from ast import pattern
 import os.path
-from typing import Union
+import re
+from typing import Union, Optional
 
 import hail as hl
 from utils.utils import parse_config, path_spark
-from wes_qc import hail_utils
+from wes_qc import hail_utils, vcf_utils
 
 # TODO move to utils constants
 fail_string = "FAIL"
@@ -14,7 +16,7 @@ pass_stringent_string = "PASS_STRINGENT"
 
 
 def export_vcfs(
-    mtfile: str, filtered_vcf_dir: str, hard_filters: dict[str, dict[str, dict[str : Union[int, float]]]], model_id: str
+    mtfile: str, filtered_vcf_dir: str, hard_filters: dict[str, dict[str, dict[str : Union[int, float]]]], model_id: str, csq_file: Optional[str] = None, header_file: Optional[str] = None
 ):
     """
     Export VCFs annotated with a range of hard filters
@@ -174,22 +176,6 @@ def export_vcfs(
                 "Number": "A",
                 "Type": "Float",
             },
-            "CSQ": {
-                "Description": "Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE_SELECT|MANE_PLUS_CLINICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|UNIPROT_ISOFORM|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|gnomADe_AF|gnomADe_AFR_AF|gnomADe_AMR_AF|gnomADe_ASJ_AF|gnomADe_EAS_AF|gnomADe_FIN_AF|gnomADe_NFE_AF|gnomADe_OTH_AF|gnomADe_SAS_AF|gnomADg_AF|gnomADg_AFR_AF|gnomADg_AMI_AF|gnomADg_AMR_AF|gnomADg_ASJ_AF|gnomADg_EAS_AF|gnomADg_FIN_AF|gnomADg_MID_AF|gnomADg_NFE_AF|gnomADg_OTH_AF|gnomADg_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|TRANSCRIPTION_FACTORS|PHENOTYPES|Conservation",
-                "Number": "A",
-                "Type": "String",
-            },
-            "consequence": {"Description": "Most severe consequence from VEP110", "Number": "A", "Type": "String"},
-            "gene": {
-                "Description": "Gene affected by the most severe consequence from VEP110",
-                "Number": "A",
-                "Type": "String",
-            },
-            "hgnc_id": {
-                "Description": "HGNC id of the gene affected by the most severe consequence from VEP110",
-                "Number": "A",
-                "Type": "String",
-            },
         },
         "format": {
             "HetAB": {"Description": "Hetrozygous allele balance", "Number": "A", "Type": "Float"},
@@ -210,6 +196,8 @@ def export_vcfs(
             },
         },
     }
+
+    metadata =vcf_utils.modify_vcf_metadata(metadata, csq_file, header_file)
 
     # export per chromosome
     chroms = [*range(1, 23), "X", "Y"]
@@ -233,13 +221,15 @@ def main():
 
     # = STEP DEPENDENCIES = #
     mtfile = config["step4"]["export_vcfs_a"]["mtfile"]
+    csq_file = config["step4"]["annotate_cq_rf"]["cqfile"]
+    csq_header_file =config["step4"]["annotate_cq_rf"]["csq_header"]
 
     # = STEP OUTPUTS = #
     filtered_vcf_dir = config["step4"]["export_vcfs_a"]["vcf_output_dir"]
 
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
-    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id)
+    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id, csq_file, csq_header_file)
 
 
 if __name__ == "__main__":

--- a/4-genotype_qc/3b-export_vcfs_stringent_filters.py
+++ b/4-genotype_qc/3b-export_vcfs_stringent_filters.py
@@ -1,5 +1,5 @@
 # export to VCF after annotating with a range of hard filters - flexible filter level
-from typing import Union
+from typing import Union, Any, Optional
 import argparse
 import hail as hl
 import os.path
@@ -52,10 +52,11 @@ def export_vcfs(
         mt.medium_pass_count,
         mt.relaxed_pass_count,
         mt.adj,
-        mt.assigned_pop,
         mt.sum_AD,
     )
-    
+    if "assigned_pop" in mt.col:
+        mt = mt.drop(mt.assigned_pop)
+   
     # Drop the fraction fields for other filter levels
     other_levels = [level for level in valid_levels if level != filter_level]
     info_drops = [f"fraction_pass_{level}_filters" for level in other_levels]
@@ -140,6 +141,16 @@ def export_vcfs(
     }
 
     metadata =vcf_utils.modify_vcf_metadata(metadata, csq_file, header_file)
+    if csq_file is None:
+        if 'CSQ' in mt.info.dtype.fields:
+            mt = mt.annotate_rows(
+                info=mt.info.drop('CSQ', 'consequence', 'gene', 'hgnc_id')
+            )
+    elif not metadata["info"].get("CSQ"):
+        if 'CSQ' in mt.info.dtype.fields:
+            mt = mt.annotate_rows(
+                info=mt.info.drop('CSQ')
+            )
 
     # Export per chromosome
     chroms = [*range(1, 23), "X", "Y"]
@@ -151,9 +162,10 @@ def export_vcfs(
         outfile = os.path.join(path_spark(filtered_vcf_dir), f"{chromosome}_{filter_level}_filters.vcf.bgz")
         hl.export_vcf(mt_chrom, outfile, metadata=metadata)
 
-
-def main():
-    # Parse command line arguments
+def get_options() -> argparse.Namespace:
+    """
+    Get options from the command line
+    """
     parser = argparse.ArgumentParser(
         description="Export VCFs with specified filter level (relaxed, medium, or stringent)"
     )
@@ -165,7 +177,11 @@ def main():
         help="Filter level to apply (default: stringent)"
     )
     args = parser.parse_args()
+    return args
 
+def main():
+    # Parse command line arguments
+    args = get_options()
     # = STEP SETUP = #
     config = parse_config()
     tmp_dir = config["general"]["tmp_dir"]

--- a/4-genotype_qc/3b-export_vcfs_stringent_filters.py
+++ b/4-genotype_qc/3b-export_vcfs_stringent_filters.py
@@ -4,7 +4,7 @@ import argparse
 import hail as hl
 import os.path
 from utils.utils import parse_config, path_spark
-from wes_qc import hail_utils
+from wes_qc import hail_utils, vcf_utils
 
 
 def export_vcfs(
@@ -12,6 +12,8 @@ def export_vcfs(
     filtered_vcf_dir: str,
     hard_filters: dict[str, dict[str, dict[str, Union[int, float]]]],
     model_id: str,
+    csq_file: Optional[str] = None,
+    header_file: Optional[str] = None,
     filter_level: str = "stringent"
 ):
     """
@@ -134,24 +136,10 @@ def export_vcfs(
                 "Number": "A",
                 "Type": "Integer",
             },
-            "CSQ": {
-                "Description": "Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE_SELECT|MANE_PLUS_CLINICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|UNIPROT_ISOFORM|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|gnomADe_AF|gnomADe_AFR_AF|gnomADe_AMR_AF|gnomADe_ASJ_AF|gnomADe_EAS_AF|gnomADe_FIN_AF|gnomADe_NFE_AF|gnomADe_OTH_AF|gnomADe_SAS_AF|gnomADg_AF|gnomADg_AFR_AF|gnomADg_AMI_AF|gnomADg_AMR_AF|gnomADg_ASJ_AF|gnomADg_EAS_AF|gnomADg_FIN_AF|gnomADg_MID_AF|gnomADg_NFE_AF|gnomADg_OTH_AF|gnomADg_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|TRANSCRIPTION_FACTORS|PHENOTYPES|Conservation",
-                "Number": "A",
-                "Type": "String",
-            },
-            "consequence": {"Description": "Most severe consequence from VEP104", "Number": "A", "Type": "String"},
-            "gene": {
-                "Description": "Gene affected by the most severe consequence from VEP104",
-                "Number": "A",
-                "Type": "String",
-            },
-            "hgnc_id": {
-                "Description": "HGNC id of the gene affected by the most severe consequence from VEP104",
-                "Number": "A",
-                "Type": "String",
-            },
         },
     }
+
+    metadata =vcf_utils.modify_vcf_metadata(metadata, csq_file, header_file)
 
     # Export per chromosome
     chroms = [*range(1, 23), "X", "Y"]
@@ -188,13 +176,15 @@ def main():
 
     # = STEP DEPENDENCIES = #
     mtfile = config["step4"]["export_vcfs_b"]["mtfile"]
+    csq_file = config["step4"]["annotate_cq_rf"]["cqfile"]
+    csq_header_file =config["step4"]["annotate_cq_rf"]["csq_header"]
 
     # = STEP OUTPUTS = #
     filtered_vcf_dir = config["step4"]["export_vcfs_b"]["filtered_vcf_dir"]
 
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
-    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id, filter_level=args.filter_level)
+    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id, csq_file, csq_header_file, filter_level=args.filter_level)
 
 
 if __name__ == "__main__":

--- a/4-genotype_qc/3b-export_vcfs_stringent_filters.py
+++ b/4-genotype_qc/3b-export_vcfs_stringent_filters.py
@@ -1,6 +1,6 @@
-# export to VCF after annotating with a range of hard filters - stringent filters only, remove other gts
+# export to VCF after annotating with a range of hard filters - flexible filter level
 from typing import Union
-
+import argparse
 import hail as hl
 import os.path
 from utils.utils import parse_config, path_spark
@@ -8,7 +8,11 @@ from wes_qc import hail_utils
 
 
 def export_vcfs(
-    mtfile: str, filtered_vcf_dir: str, hard_filters: dict[str, dict[str, dict[str : Union[int, float]]]], model_id: str
+    mtfile: str,
+    filtered_vcf_dir: str,
+    hard_filters: dict[str, dict[str, dict[str, Union[int, float]]]],
+    model_id: str,
+    filter_level: str = "stringent"
 ):
     """
     Export VCFs annotated with a range of hard filters
@@ -16,14 +20,28 @@ def export_vcfs(
     :param str filtered_vcf_dir: output directory for VCFs
     :param dict hard_filters: details of all sets of filters
     :param str model_id: random forest run hash used
+    :param str filter_level: filter level to apply - 'relaxed', 'medium', or 'stringent'
     """
+    # Validate filter level
+    valid_levels = ["relaxed", "medium", "stringent"]
+    if filter_level not in valid_levels:
+        raise ValueError(f"filter_level must be one of {valid_levels}, got '{filter_level}'")
+    
     mt = hl.read_matrix_table(path_spark(mtfile))
 
-    # filter to remove rows where all variants fail the most stringent filters,
-    mt = mt.filter_rows(mt.info.fraction_pass_stringent_filters > 0)
-    mt = mt.filter_entries(mt.stringent_filters == "Pass")
+    # Define field names based on filter level
+    fraction_field = f"fraction_pass_{filter_level}_filters"
+    filter_field = f"{filter_level}_filters"
+    an_field = f"{filter_level}_AN"
+    ac_field = f"{filter_level}_AC"
+    ac_hom_field = f"{filter_level}_AC_Hom"
+    ac_het_field = f"{filter_level}_AC_Het"
 
-    # drop unwanted fields
+    # Filter to remove rows where all variants fail the selected filters
+    mt = mt.filter_rows(mt.info[fraction_field] > 0)
+    mt = mt.filter_entries(mt[filter_field] == "Pass")
+
+    # Drop unwanted fields
     mt = mt.drop(
         mt.a_index,
         mt.was_split,
@@ -35,56 +53,91 @@ def export_vcfs(
         mt.assigned_pop,
         mt.sum_AD,
     )
-    mt = mt.annotate_rows(info=mt.info.drop("fraction_pass_medium_filters", "fraction_pass_relaxed_filters"))
+    
+    # Drop the fraction fields for other filter levels
+    other_levels = [level for level in valid_levels if level != filter_level]
+    info_drops = [f"fraction_pass_{level}_filters" for level in other_levels]
+    mt = mt.annotate_rows(info=mt.info.drop(*info_drops))
+    
+    # Recalculating AC, AN, AC_Hom, AC_Het based on filter results
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            AN=mt[an_field],
+            AC=mt[ac_field],
+            AC_Hom=mt[ac_hom_field],
+            AC_Het=mt[ac_het_field]
+        )
+    )
+    
+    # Remove variants with AC equals 0
+    mt = mt.filter_rows(mt.info.AC == [0], keep=False)
+    
+    # Remove all filter columns
+    mt = mt.drop(mt.relaxed_filters, mt.medium_filters, mt.stringent_filters)
+    
+    # Calculate AF
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            AF=mt.info.AC / mt.info.AN
+        )
+    )
 
-    # info for header
-    stringent_filters = (
-        "SNPs: RF bin<="
-        + str(hard_filters["snp"]["stringent"]["bin"])
-        + " & DP>="
-        + str(hard_filters["snp"]["stringent"]["dp"])
-        + " & GQ>="
-        + str(hard_filters["snp"]["stringent"]["gq"])
-        + " & HetAB>="
-        + str(hard_filters["snp"]["stringent"]["ab"])
-        + " & Call_Rate>="
-        + str(hard_filters["snp"]["stringent"]["call_rate"])
-        + ", Indels: RF bin<="
-        + str(hard_filters["indel"]["stringent"]["bin"])
-        + " & DP>="
-        + str(hard_filters["indel"]["stringent"]["dp"])
-        + " & GQ>="
-        + str(hard_filters["indel"]["stringent"]["gq"])
-        + " & HetAB>="
-        + str(hard_filters["indel"]["stringent"]["ab"])
-        + " & Call_Rate>="
-        + str(hard_filters["indel"]["stringent"]["call_rate"])
+    # Info for header - construct filter description
+    filter_desc = (
+        f"SNPs: RF bin<={hard_filters['snp'][filter_level]['bin']}"
+        f" & DP>={hard_filters['snp'][filter_level]['dp']}"
+        f" & GQ>={hard_filters['snp'][filter_level]['gq']}"
+        f" & HetAB>={hard_filters['snp'][filter_level]['ab']}"
+        f" & Call_Rate>={hard_filters['snp'][filter_level]['call_rate']}"
+        f", Indels: RF bin<={hard_filters['indel'][filter_level]['bin']}"
+        f" & DP>={hard_filters['indel'][filter_level]['dp']}"
+        f" & GQ>={hard_filters['indel'][filter_level]['gq']}"
+        f" & HetAB>={hard_filters['indel'][filter_level]['ab']}"
+        f" & Call_Rate>={hard_filters['indel'][filter_level]['call_rate']}"
     )
 
     metadata = {
         "format": {
             "HetAB": {"Description": "Hetrozygous allele balance", "Number": "A", "Type": "Float"},
-            "stringent_filters": {
-                "Description": "Pass/fail stringent hard filters " + stringent_filters,
+            f"{filter_level}_filters": {
+                "Description": f"Pass/fail {filter_level} hard filters {filter_desc}",
                 "Number": "A",
                 "Type": "String",
             },
         },
         "info": {
-            "fraction_pass_stringent_filters": {
-                "Description": "Fraction of genotypes which pass stringent hard filters " + stringent_filters,
+            f"fraction_pass_{filter_level}_filters": {
+                "Description": f"Fraction of genotypes which pass {filter_level} hard filters {filter_desc}",
                 "Number": "A",
                 "Type": "Float",
             },
             "rf_score": {
-                "Description": "Variant QC random forest score, model id " + model_id,
+                "Description": f"Variant QC random forest score, model id {model_id}",
                 "Number": "A",
                 "Type": "Float",
             },
             "rf_bin": {
-                "Description": "Variant QC random forest bin, model id " + model_id,
+                "Description": f"Variant QC random forest bin, model id {model_id}",
                 "Number": "A",
                 "Type": "Integer",
+            },
+            "AN": {
+                "Description": "Total number of alleles in called genotypes after QC",
+                "Number": "1",
+                "Type": "Integer",
+            },
+            "AC": {"Description": "Allele count in genotypes after QC", "Number": "A", "Type": "Integer"},
+            "AF": {"Description": "Allele Frequency for ALT allele after QC", "Number": "A", "Type": "Integer"},
+            "AC_Hom": {"Description": "Allele counts in homozygous genotypes after QC", "Number": "A", "Type": "Integer"},
+            "AC_Het": {
+                "Description": "Allele counts in heterozygous genotypes after QC",
+                "Number": "A",
+                "Type": "Integer",
+            },
+            "CSQ": {
+                "Description": "Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE_SELECT|MANE_PLUS_CLINICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|UNIPROT_ISOFORM|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|gnomADe_AF|gnomADe_AFR_AF|gnomADe_AMR_AF|gnomADe_ASJ_AF|gnomADe_EAS_AF|gnomADe_FIN_AF|gnomADe_NFE_AF|gnomADe_OTH_AF|gnomADe_SAS_AF|gnomADg_AF|gnomADg_AFR_AF|gnomADg_AMI_AF|gnomADg_AMR_AF|gnomADg_ASJ_AF|gnomADg_EAS_AF|gnomADg_FIN_AF|gnomADg_MID_AF|gnomADg_NFE_AF|gnomADg_OTH_AF|gnomADg_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|TRANSCRIPTION_FACTORS|PHENOTYPES|Conservation",
+                "Number": "A",
+                "Type": "String",
             },
             "consequence": {"Description": "Most severe consequence from VEP104", "Number": "A", "Type": "String"},
             "gene": {
@@ -100,18 +153,31 @@ def export_vcfs(
         },
     }
 
-    # export per chromosome
+    # Export per chromosome
     chroms = [*range(1, 23), "X", "Y"]
     chromosomes = [f"chr{str(chr)}" for chr in chroms]
     for chromosome in chromosomes:
-        print("Exporting " + chromosome)
+        print(f"Exporting {chromosome}")
         mt_chrom = mt.annotate_globals(chromosome=chromosome)
         mt_chrom = mt_chrom.filter_rows(mt_chrom.locus.contig == mt_chrom.chromosome)
-        outfile = os.path.join(path_spark(filtered_vcf_dir), f"{chromosome}_stringent_filters.vcf.bgz")
+        outfile = os.path.join(path_spark(filtered_vcf_dir), f"{chromosome}_{filter_level}_filters.vcf.bgz")
         hl.export_vcf(mt_chrom, outfile, metadata=metadata)
 
 
 def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Export VCFs with specified filter level (relaxed, medium, or stringent)"
+    )
+    parser.add_argument(
+        "--filter-level",
+        type=str,
+        choices=["relaxed", "medium", "stringent"],
+        default="stringent",
+        help="Filter level to apply (default: stringent)"
+    )
+    args = parser.parse_args()
+
     # = STEP SETUP = #
     config = parse_config()
     tmp_dir = config["general"]["tmp_dir"]
@@ -128,7 +194,7 @@ def main():
 
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
-    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id)
+    export_vcfs(mtfile, filtered_vcf_dir, hard_filters, model_id, filter_level=args.filter_level)
 
 
 if __name__ == "__main__":

--- a/4-genotype_qc/4-counts_per_sample.py
+++ b/4-genotype_qc/4-counts_per_sample.py
@@ -106,7 +106,7 @@ def get_counts_per_cq(mt_in: hl.MatrixTable, outfile: str):
 
     # print out medians
     print("Median variant counts per sample for each functional class:")
-    print("Synonymous: All variants" + str(np.median(synonymous_all)) + " rare " + str(np.median(synonymous_rare)))
+    print("Synonymous: All variants " + str(np.median(synonymous_all)) + " rare " + str(np.median(synonymous_rare)))
     print("Missense: All variants " + str(np.median(missense_all)) + " rare " + str(np.median(missense_rare)))
     print("Nonsense: All variants " + str(np.median(nonsense_all)) + " rare " + str(np.median(nonsense_rare)))
     print("Splicing: All variants " + str(np.median(splice_all)) + " rare " + str(np.median(splice_rare)))
@@ -238,71 +238,68 @@ def main():
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
 
-    print("=== Annotating-pre-filtered mt with consequence, gene, rf bin ===")
-    rf_htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")  # move runhash to config
-    mt = hl.read_matrix_table(path_spark(mt_prefiltered_file))
-    mt_annot = step4_2.annotate_rf(mt, rf_htfile)
     if cqfile is not None:
+        print("=== Annotating-pre-filtered mt with consequence, gene, rf bin ===")
+        rf_htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")  # move runhash to config
+        mt = hl.read_matrix_table(path_spark(mt_prefiltered_file))
+        mt_annot = step4_2.annotate_rf(mt, rf_htfile)
         mt_annot = step4_2.annotate_cq(mt_annot, cqfile)
-    else:
-        mt_annot = mt_annot.annotate_rows(
-            info=mt_annot.info.annotate(
-                consequence=hl.missing(hl.tstr)
-            )
+        print("--- Pre-filtering variants stats ---")
+
+        vars_preqc = mt_annot.rows()
+        vars_preqc = vars_preqc.repartition(24)
+        cq_prefilter_stats = stats.count_vars_per_cq(
+            vars_preqc, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
         )
-    print("--- Pre-filtering variants stats ---")
 
-    vars_preqc = mt_annot.rows()
-    vars_preqc = vars_preqc.repartition(24)
-    cq_prefilter_stats = stats.count_vars_per_cq(
-        vars_preqc, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-    )
+        print("=== Post-filtering variants stats ===")
+        mt = hl.read_matrix_table(path_spark(mtfile))
+        vars_afterqc = mt.rows()
+        vars_afterqc = vars_afterqc.repartition(24)
+        # Checkpointing table to speed up multiple time-consuming filtering
+        vars_afterqc = vars_afterqc.checkpoint(tmp_dir + "/step4_apply_hard_filters_vars_afterqc.ht", overwrite=True)
 
-    print("=== Post-filtering variants stats ===")
-    mt = hl.read_matrix_table(path_spark(mtfile))
-    vars_afterqc = mt.rows()
-    vars_afterqc = vars_afterqc.repartition(24)
-    # Checkpointing table to speed up multiple time-consuming filtering
-    vars_afterqc = vars_afterqc.checkpoint(tmp_dir + "/step4_apply_hard_filters_vars_afterqc.ht", overwrite=True)
+        vars_afterqc_relaxed = vars_afterqc.filter(vars_afterqc.relaxed_pass_count > 0)
+        cq_afterfilter_stats_relaxed = stats.count_vars_per_cq(
+            vars_afterqc_relaxed, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+        )
 
-    vars_afterqc_relaxed = vars_afterqc.filter(vars_afterqc.relaxed_pass_count > 0)
-    cq_afterfilter_stats_relaxed = stats.count_vars_per_cq(
-        vars_afterqc_relaxed, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-    )
+        vars_afterqc_medium = vars_afterqc.filter(vars_afterqc.medium_pass_count > 0)
+        cq_afterfilter_stats_medium = stats.count_vars_per_cq(
+            vars_afterqc_medium, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+        )
 
-    vars_afterqc_medium = vars_afterqc.filter(vars_afterqc.medium_pass_count > 0)
-    cq_afterfilter_stats_medium = stats.count_vars_per_cq(
-        vars_afterqc_medium, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-    )
+        vars_afterqc_stringent = vars_afterqc.filter(vars_afterqc.stringent_pass_count > 0)
+        cq_afterfilter_stats_stringent = stats.count_vars_per_cq(
+            vars_afterqc_stringent, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+        )
 
-    vars_afterqc_stringent = vars_afterqc.filter(vars_afterqc.stringent_pass_count > 0)
-    cq_afterfilter_stats_stringent = stats.count_vars_per_cq(
-        vars_afterqc_stringent, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-    )
+        # Combine the three dictionaries into a DataFrame
+        cq_stats_df = pd.DataFrame(
+            [cq_prefilter_stats, cq_afterfilter_stats_relaxed, cq_afterfilter_stats_medium, cq_afterfilter_stats_stringent],
+            index=["unfiltered", "relaxed", "medium", "stringent"],
+        )
+        # Collecting consequences actually present in our data
+        vep_csq_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_CODING if csq in cq_stats_df.columns]
+        vep_csq_non_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_NON_CODING if csq in cq_stats_df.columns]
 
-    # Combine the three dictionaries into a DataFrame
-    cq_stats_df = pd.DataFrame(
-        [cq_prefilter_stats, cq_afterfilter_stats_relaxed, cq_afterfilter_stats_medium, cq_afterfilter_stats_stringent],
-        index=["unfiltered", "relaxed", "medium", "stringent"],
-    )
-    # Collecting consequences actually present in our data
-    vep_csq_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_CODING if csq in cq_stats_df.columns]
-    vep_csq_non_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_NON_CODING if csq in cq_stats_df.columns]
+        cq_stats_df["total_coding"] = cq_stats_df[vep_csq_coding_present].sum(axis=1)
+        cq_stats_df["total_noncoding"] = cq_stats_df[vep_csq_non_coding_present].sum(axis=1)
 
-    cq_stats_df["total_coding"] = cq_stats_df[vep_csq_coding_present].sum(axis=1)
-    cq_stats_df["total_noncoding"] = cq_stats_df[vep_csq_non_coding_present].sum(axis=1)
+        cq_stats_df = cq_stats_df[
+            vep_csq_coding_present + ["total_coding"] + vep_csq_non_coding_present + ["total_noncoding"]
+        ]
+        cq_stats_df.to_csv(config["step4"]["get_counts_per_cq"]["cq_stats_df"], sep="\t")
 
-    cq_stats_df = cq_stats_df[
-        vep_csq_coding_present + ["total_coding"] + vep_csq_non_coding_present + ["total_noncoding"]
-    ]
-    cq_stats_df.to_csv(config["step4"]["get_counts_per_cq"]["cq_stats_df"], sep="\t")
+        mt = annotate_gnomad(mt, gnomad_htfile)
+        # TODO: make optional as it only prints info to stdout
+        # pedfile = config["step4"]["get_trans_untrans_synon_singleton_counts"]["pedfile"]
+        # get_trans_untrans_synon_singleton_counts(mt, pedfile) # test data has no trios
+        cq_out_file = config["step4"]["get_counts_per_cq"]["cq_out_file"]
+        get_counts_per_cq(mt, cq_out_file)
 
-    mt = annotate_gnomad(mt, gnomad_htfile)
-    # TODO: make optional as it only prints info to stdout
-    # pedfile = config["step4"]["get_trans_untrans_synon_singleton_counts"]["pedfile"]
-    # get_trans_untrans_synon_singleton_counts(mt, pedfile) # test data has no trios
-    cq_out_file = config["step4"]["get_counts_per_cq"]["cq_out_file"]
-    get_counts_per_cq(mt, cq_out_file)
+    else:
+        print("=== No cqfile provided, skipping annotation of consequence and gene info. Counts per consequence can't be calculated. ===")
 
 
 if __name__ == "__main__":

--- a/4-genotype_qc/4-counts_per_sample.py
+++ b/4-genotype_qc/4-counts_per_sample.py
@@ -238,68 +238,69 @@ def main():
     # = STEP LOGIC = #
     _ = hail_utils.init_hl(tmp_dir)
 
-    if cqfile is not None:
-        print("=== Annotating-pre-filtered mt with consequence, gene, rf bin ===")
-        rf_htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")  # move runhash to config
-        mt = hl.read_matrix_table(path_spark(mt_prefiltered_file))
-        mt_annot = step4_2.annotate_rf(mt, rf_htfile)
-        mt_annot = step4_2.annotate_cq(mt_annot, cqfile)
-        print("--- Pre-filtering variants stats ---")
-
-        vars_preqc = mt_annot.rows()
-        vars_preqc = vars_preqc.repartition(24)
-        cq_prefilter_stats = stats.count_vars_per_cq(
-            vars_preqc, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+    if cqfile is None:
+        print(
+            "=== No cqfile provided, skipping annotation of consequence and gene info. Counts per consequence can't be calculated. ==="
         )
+        return
+    print("=== Annotating-pre-filtered mt with consequence, gene, rf bin ===")
+    rf_htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")  # move runhash to config
+    mt = hl.read_matrix_table(path_spark(mt_prefiltered_file))
+    mt_annot = step4_2.annotate_rf(mt, rf_htfile)
+    mt_annot = step4_2.annotate_cq(mt_annot, cqfile)
+    print("--- Pre-filtering variants stats ---")
 
-        print("=== Post-filtering variants stats ===")
-        mt = hl.read_matrix_table(path_spark(mtfile))
-        vars_afterqc = mt.rows()
-        vars_afterqc = vars_afterqc.repartition(24)
-        # Checkpointing table to speed up multiple time-consuming filtering
-        vars_afterqc = vars_afterqc.checkpoint(tmp_dir + "/step4_apply_hard_filters_vars_afterqc.ht", overwrite=True)
+    vars_preqc = mt_annot.rows()
+    vars_preqc = vars_preqc.repartition(24)
+    cq_prefilter_stats = stats.count_vars_per_cq(
+        vars_preqc, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+    )
 
-        vars_afterqc_relaxed = vars_afterqc.filter(vars_afterqc.relaxed_pass_count > 0)
-        cq_afterfilter_stats_relaxed = stats.count_vars_per_cq(
-            vars_afterqc_relaxed, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-        )
+    print("=== Post-filtering variants stats ===")
+    mt = hl.read_matrix_table(path_spark(mtfile))
+    vars_afterqc = mt.rows()
+    vars_afterqc = vars_afterqc.repartition(24)
+    # Checkpointing table to speed up multiple time-consuming filtering
+    vars_afterqc = vars_afterqc.checkpoint(tmp_dir + "/step4_apply_hard_filters_vars_afterqc.ht", overwrite=True)
 
-        vars_afterqc_medium = vars_afterqc.filter(vars_afterqc.medium_pass_count > 0)
-        cq_afterfilter_stats_medium = stats.count_vars_per_cq(
-            vars_afterqc_medium, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-        )
+    vars_afterqc_relaxed = vars_afterqc.filter(vars_afterqc.relaxed_pass_count > 0)
+    cq_afterfilter_stats_relaxed = stats.count_vars_per_cq(
+        vars_afterqc_relaxed, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+    )
 
-        vars_afterqc_stringent = vars_afterqc.filter(vars_afterqc.stringent_pass_count > 0)
-        cq_afterfilter_stats_stringent = stats.count_vars_per_cq(
-            vars_afterqc_stringent, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
-        )
+    vars_afterqc_medium = vars_afterqc.filter(vars_afterqc.medium_pass_count > 0)
+    cq_afterfilter_stats_medium = stats.count_vars_per_cq(
+        vars_afterqc_medium, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+    )
 
-        # Combine the three dictionaries into a DataFrame
-        cq_stats_df = pd.DataFrame(
-            [cq_prefilter_stats, cq_afterfilter_stats_relaxed, cq_afterfilter_stats_medium, cq_afterfilter_stats_stringent],
-            index=["unfiltered", "relaxed", "medium", "stringent"],
-        )
-        # Collecting consequences actually present in our data
-        vep_csq_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_CODING if csq in cq_stats_df.columns]
-        vep_csq_non_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_NON_CODING if csq in cq_stats_df.columns]
+    vars_afterqc_stringent = vars_afterqc.filter(vars_afterqc.stringent_pass_count > 0)
+    cq_afterfilter_stats_stringent = stats.count_vars_per_cq(
+        vars_afterqc_stringent, constants.VEP_CONSEQUENCE_CODING + constants.VEP_CONSEQUENCE_NON_CODING
+    )
 
-        cq_stats_df["total_coding"] = cq_stats_df[vep_csq_coding_present].sum(axis=1)
-        cq_stats_df["total_noncoding"] = cq_stats_df[vep_csq_non_coding_present].sum(axis=1)
+    # Combine the three dictionaries into a DataFrame
+    cq_stats_df = pd.DataFrame(
+        [cq_prefilter_stats, cq_afterfilter_stats_relaxed, cq_afterfilter_stats_medium, cq_afterfilter_stats_stringent],
+        index=["unfiltered", "relaxed", "medium", "stringent"],
+    )
+    # Collecting consequences actually present in our data
+    vep_csq_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_CODING if csq in cq_stats_df.columns]
+    vep_csq_non_coding_present = [csq for csq in constants.VEP_CONSEQUENCE_NON_CODING if csq in cq_stats_df.columns]
 
-        cq_stats_df = cq_stats_df[
-            vep_csq_coding_present + ["total_coding"] + vep_csq_non_coding_present + ["total_noncoding"]
-        ]
-        cq_stats_df.to_csv(config["step4"]["get_counts_per_cq"]["cq_stats_df"], sep="\t")
+    cq_stats_df["total_coding"] = cq_stats_df[vep_csq_coding_present].sum(axis=1)
+    cq_stats_df["total_noncoding"] = cq_stats_df[vep_csq_non_coding_present].sum(axis=1)
 
-        mt = annotate_gnomad(mt, gnomad_htfile)
-        # TODO: make optional as it only prints info to stdout
-        # pedfile = config["step4"]["get_trans_untrans_synon_singleton_counts"]["pedfile"]
-        # get_trans_untrans_synon_singleton_counts(mt, pedfile) # test data has no trios
-        cq_out_file = config["step4"]["get_counts_per_cq"]["cq_out_file"]
-        get_counts_per_cq(mt, cq_out_file)
+    cq_stats_df = cq_stats_df[
+        vep_csq_coding_present + ["total_coding"] + vep_csq_non_coding_present + ["total_noncoding"]
+    ]
+    cq_stats_df.to_csv(config["step4"]["get_counts_per_cq"]["cq_stats_df"], sep="\t")
 
-    else:
-        print("=== No cqfile provided, skipping annotation of consequence and gene info. Counts per consequence can't be calculated. ===")
+    mt = annotate_gnomad(mt, gnomad_htfile)
+    # TODO: make optional as it only prints info to stdout
+    # pedfile = config["step4"]["get_trans_untrans_synon_singleton_counts"]["pedfile"]
+    # get_trans_untrans_synon_singleton_counts(mt, pedfile) # test data has no trios
+    cq_out_file = config["step4"]["get_counts_per_cq"]["cq_out_file"]
+    get_counts_per_cq(mt, cq_out_file)
 
 
 if __name__ == "__main__":

--- a/4-genotype_qc/4-counts_per_sample.py
+++ b/4-genotype_qc/4-counts_per_sample.py
@@ -54,7 +54,10 @@ def get_trans_untrans_synon_singleton_counts(mt_in: hl.MatrixTable, pedfile: str
 
     untrans_sing = tdt_ht_untrans.filter((tdt_ht_untrans.t == 0) & (tdt_ht_untrans.u == 1))
     untrans = untrans_sing.count()
-    ratio = trans / untrans
+    if untrans > 0:
+        ratio = trans / untrans
+    else:
+        ratio = -1  # Sentinel value indicating undefined ratio
 
     print(
         "There are "
@@ -238,7 +241,15 @@ def main():
     print("=== Annotating-pre-filtered mt with consequence, gene, rf bin ===")
     rf_htfile = os.path.join(rf_dir, model_id, "_gnomad_score_binning_tmp.ht")  # move runhash to config
     mt = hl.read_matrix_table(path_spark(mt_prefiltered_file))
-    mt_annot = step4_2.annotate_cq_rf(mt, rf_htfile, cqfile)
+    mt_annot = step4_2.annotate_rf(mt, rf_htfile)
+    if cqfile is not None:
+        mt_annot = step4_2.annotate_cq(mt_annot, cqfile)
+    else:
+        mt_annot = mt_annot.annotate_rows(
+            info=mt_annot.info.annotate(
+                consequence=hl.missing(hl.tstr)
+            )
+        )
     print("--- Pre-filtering variants stats ---")
 
     vars_preqc = mt_annot.rows()

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -474,6 +474,10 @@ step4:
     cqfile: '${general.metadata.vep_consequences}'
 
   apply_hard_filters:
+    # Set to true if you want to apply different hard filters for sex chromosomes in male samples (depth threshold will be halfed for sex chromosome).
+    sex_chromosome_specific_filtering: True
+    # A file similar to self_reported_sex with resolved annotation conflicts. This file is used when sex_chromosome_specific_filtering is true
+    sex_annotation_file: '${general.metadata_dir}/${general.dataset_name}.self_reported_sex.tsv'
     hard_filters:
       snp:
         relaxed:

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -71,17 +71,20 @@ step0:
     kg_pop_file: '${cvars.resdir}/igsr_samples.tsv'
     kg_unprocessed: '${cvars.mtdir}/kg_unprocessed.mt'
     filtered_kg_file: '${cvars.mtdir}/kg_filtered.mt'
-    #pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt'
     long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
     samples_to_remove_file: '${cvars.mtdir}/kg_related_samples_to_remove.ht'
+    filter_params:
+      call_rate_threshold: 0.99
+      af_threshold: 0.05
+      hwe_threshold: 0.00001 #1e-5
 
     king_params:
-      king_kg_file: '${cvars.mtdir}/king_kg.ht'
-      unrelated_kg_king_file: '${cvars.mtdir}/unrelated_kg_king.mt' # output
-      related_kg_king_file: '${cvars.mtdir}/related_kg_king.mt' # output
+      king_output_file: '${cvars.mtdir}/king_kg.ht'
+      unrelated_king_file: '${cvars.mtdir}/unrelated_kg_king.mt' # output
+      related_king_file: '${cvars.mtdir}/related_kg_king.mt' # output
       kinship_threshold: 0.0442 
     prune_params:
-      pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt' # output
+      pruned_mt_file: '${cvars.mtdir}/kg_pruned_ld.mt' # output
       ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
         r2: 0.2
         # bp_window_size:
@@ -93,7 +96,6 @@ step0:
       unrelated_samples_scores_file: '${cvars.mtdir}/kg.king_unrelated_samples.pca_scores.ht' # output
       pca_loadings_file_pc_relate: '${cvars.mtdir}/kg.king_unrelated_samples.pca_loadings.ht' # output
       scores_file: '${cvars.mtdir}/kg_filtered.pca_scores.ht'
-      relatedness_ht_file: '${cvars.mtdir}/kg_relatedness.ht'
       pca_components: 10
       pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
         min_individual_maf: 0.05
@@ -104,14 +106,8 @@ step0:
         # include_self_kinship:
       relatedness_column: 'kin'
       relatedness_threshold: 0.125
-      #relatedness_outfile: '${cvars.anndir}/relatedness.tsv.gz'
-      #relatedness_plotfile: '${cvars.pltdir}/relatedness_plot.html'
 
     kg_out_mt: '${cvars.mtdir}/kg_wes_regions.mt' # output
-    filter_params:
-      call_rate_threshold: 0.99
-      af_threshold: 0.05
-      hwe_threshold: 0.00001 #1e-5
 
   generate_truthset_ht:
     omni: '${cvars.resdir}/1000G_omni2.5.hg38.vcf.gz'
@@ -187,32 +183,29 @@ step2:
     conflicting_sex_report_file: '${cvars.anndir}/conflicting_sex.tsv' # output
 
   # --- Step 2.2 --- #
-  filter_before_pruning:
-    long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
+  long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
+  filter_params:
     call_rate_threshold: 0.99
     af_threshold: 0.05
     hwe_threshold: 0.00001 #1e-5
   filtered_mt_outfile: '${cvars.mtdir}/filtered_for_PCA.mt'
-  king:
+  king_params:
     king_output_file: '${cvars.mtdir}/king.ht'
     unrelated_king_file: '${cvars.mtdir}/unrelated_king.mt' # output
     related_king_file: '${cvars.mtdir}/related_king.mt' # output
     kinship_threshold: 0.0442 
-  prune:
+  prune_params:
     pruned_mt_file: '${cvars.mtdir}/mt_ldpruned.mt' # output
-    pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output
     ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
       r2: 0.2
       # bp_window_size:
       # memory_per_core:
       # keep_higher_maf:
       # block_size:
-  prune_pc_relate:
+  pc_relate_params:
     unrelated_samples_scores_file: '${cvars.mtdir}/mt_pruned.unrelated_samples.pca_scores.ht' # output
-    scores_file: '${cvars.mtdir}/mt_pruned.pca_scores.ht' # output
     pca_loadings_file_pc_relate: '${cvars.mtdir}/mt_pruned.pca_loadings.ht' # output
-    samples_to_remove_file: '${cvars.mtdir}/mt_related_samples_to_remove.ht' # output
-    samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
+    scores_file: '${cvars.mtdir}/mt_pruned.pca_scores.ht' # output
     pca_components: 10
     pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
       min_individual_maf: 0.05
@@ -223,11 +216,16 @@ step2:
       # include_self_kinship:
     relatedness_column: 'kin'
     relatedness_threshold: 0.125
+
+  relatedness_output:
     relatedness_outfile: '${cvars.anndir}/relatedness.tsv.gz'
     relatedness_plotfile: '${cvars.pltdir}/relatedness_plot.html'
+    samples_to_remove_file: '${cvars.mtdir}/mt_related_samples_to_remove.ht' # output
+    samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
 
   prune_plot_pca:
     #plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
+    pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output
     pca_components: 10
     union_pca_scores_file: '${cvars.mtdir}/mt_pca_scores.ht' # output
     pca_scores_file: '${cvars.mtdir}/mt_pca_scores.unrelated_samples.ht' # output

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -93,8 +93,6 @@ step0:
       pca_loadings_file_pc_relate: '${cvars.mtdir}/kg.king_unrelated_samples.pca_loadings.ht' # output
       scores_file: '${cvars.mtdir}/kg_filtered.pca_scores.ht'
       relatedness_ht_file: '${cvars.mtdir}/kg_relatedness.ht'
-      #samples_to_remove_file: '${cvars.mtdir}/kg_related_samples_to_remove.ht' # output
-      #samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
       pca_components: 10
       pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
         min_individual_maf: 0.05

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -164,11 +164,10 @@ step2:
   # --- Step 2.2 --- #
   filter_before_pruning:
     long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
-    filtered_mt_outfile: '${cvars.mtdir}/filtered_for_PCA.mt'
     call_rate_threshold: 0.99
     af_threshold: 0.05
     hwe_threshold: 0.00001 #1e-5
-    r2_threshold: 0.2
+  filtered_mt_outfile: '${cvars.mtdir}/filtered_for_PCA.mt'
   king:
     king_output_file: '${cvars.mtdir}/king.ht'
     unrelated_king_file: '${cvars.mtdir}/unrelated_king.mt' # output
@@ -204,7 +203,7 @@ step2:
     relatedness_plotfile: '${cvars.pltdir}/relatedness_plot.html'
 
   prune_plot_pca:
-    plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
+    #plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
     pca_components: 10
     union_pca_scores_file: '${cvars.mtdir}/mt_pca_scores.ht' # output
     pca_scores_file: '${cvars.mtdir}/mt_pca_scores.unrelated_samples.ht' # output
@@ -214,11 +213,7 @@ step2:
 
   # --- Step 2.3 --- #
   merge_1kg_and_ldprune:
-    long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
     pruned_mt_outfile: '${cvars.mtdir}/1kg_filtered_ldpruned.mt'
-    call_rate_threshold: 0.99
-    af_threshold: 0.05
-    hwe_threshold: 0.00001 #1e-5
     r2_threshold: 0.2
     pruned_and_merged_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
 

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -162,17 +162,32 @@ step2:
     conflicting_sex_report_file: '${cvars.anndir}/conflicting_sex.tsv' # output
 
   # --- Step 2.2 --- #
+  filter_before_pruning:
+    long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
+    filtered_mt_outfile: '${cvars.mtdir}/filtered_for_PCA.mt'
+    call_rate_threshold: 0.99
+    af_threshold: 0.05
+    hwe_threshold: 0.00001 #1e-5
+    r2_threshold: 0.2
+  king:
+    king_output_file: '${cvars.mtdir}/king.ht'
+    unrelated_king_file: '${cvars.mtdir}/unrelated_king.mt' # output
+    related_king_file: '${cvars.mtdir}/related_king.mt' # output
+    kinship_threshold: 0.0442 
+    divergence_threshold: -0.0442
   prune:
     pruned_mt_file: '${cvars.mtdir}/mt_ldpruned.mt' # output
+    pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output
     ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
       r2: 0.2
       # bp_window_size:
       # memory_per_core:
       # keep_higher_maf:
       # block_size:
-
   prune_pc_relate:
+    unrelated_samples_scores_file: '${cvars.mtdir}/mt_pruned.unrelated_samples.pca_scores.ht' # output
     scores_file: '${cvars.mtdir}/mt_pruned.pca_scores.ht' # output
+    pca_loadings_file_pc_relate: '${cvars.mtdir}/mt_pruned.pca_loadings.ht' # output
     samples_to_remove_file: '${cvars.mtdir}/mt_related_samples_to_remove.ht' # output
     samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
     pca_components: 10

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -292,12 +292,12 @@ step2:
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_qc_metrics_residuals
     compute_qc_metrics_residuals_args: #do not specify strata and regression_sample_inclusion_expr in compute_qc_metrics_residuals_args
-      n_pcs: 10 # Number of PCA components
+      n_pcs: 10 # Number of PCA components. Should be <= pc_components in `pc_relate_params`
 
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     #https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.determine_nearest_neighbors
     determine_nearest_neighbors_args: #do not specify add_neighbor_distances and strata here
-      n_pcs: 10 # Number of PCA components.
+      n_pcs: 10 # Number of PCA components. Should be <= pc_components in `pc_relate_params`
       n_neighbors: 50 # Number of neighbours to calculate average values
 
     # Additional parameters to pass to gnomAD sampleQC function:

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -69,24 +69,50 @@ step0:
     vcfheader: '${general.onekg_resource_dir}/header_20201028.txt' # not available for the test data, this parameter is ignored
     kg_pop_file: '${cvars.resdir}/igsr_samples.tsv'
     kg_unprocessed: '${cvars.mtdir}/kg_unprocessed.mt'
-    pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt'
+    filtered_kg_file: '${cvars.mtdir}/kg_filtered.mt'
+    #pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt'
     long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
-    relatedness_ht_file: '${cvars.mtdir}/kg_relatedness.ht'
     samples_to_remove_file: '${cvars.mtdir}/kg_related_samples_to_remove.ht'
-    scores_file: '${cvars.mtdir}/kg_pruned.pca_scores.ht'
+
+    king_params:
+      king_kg_file: '${cvars.mtdir}/king_kg.ht'
+      unrelated_kg_king_file: '${cvars.mtdir}/unrelated_kg_king.mt' # output
+      related_kg_king_file: '${cvars.mtdir}/related_kg_king.mt' # output
+      kinship_threshold: 0.0442 
+    prune_params:
+      pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt' # output
+      ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+        r2: 0.2
+        # bp_window_size:
+        # memory_per_core:
+        # keep_higher_maf:
+        # block_size:
+
+    pc_relate_params:
+      unrelated_samples_scores_file: '${cvars.mtdir}/kg.king_unrelated_samples.pca_scores.ht' # output
+      pca_loadings_file_pc_relate: '${cvars.mtdir}/kg.king_unrelated_samples.pca_loadings.ht' # output
+      scores_file: '${cvars.mtdir}/kg_filtered.pca_scores.ht'
+      relatedness_ht_file: '${cvars.mtdir}/kg_relatedness.ht'
+      #samples_to_remove_file: '${cvars.mtdir}/kg_related_samples_to_remove.ht' # output
+      #samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
+      pca_components: 10
+      pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
+        min_individual_maf: 0.05
+        block_size: 4096
+        min_kinship: 0.05
+        statistics: 'kin2'
+        # k:
+        # include_self_kinship:
+      relatedness_column: 'kin'
+      relatedness_threshold: 0.125
+      #relatedness_outfile: '${cvars.anndir}/relatedness.tsv.gz'
+      #relatedness_plotfile: '${cvars.pltdir}/relatedness_plot.html'
 
     kg_out_mt: '${cvars.mtdir}/kg_wes_regions.mt' # output
-    call_rate_threshold: 0.99
-    af_threshold: 0.05
-    hwe_threshold: 0.00001 #1e-5
-    r2_threshold: 0.2
-    hl_pc_related_kwargs:
-      min_individual_maf: 0.05
-      block_size: 4096
-      min_kinship: 0.05
-      statistics: "kin2"
-    pca_components: 10
-    kin_threshold: 0.125
+    filter_params:
+      call_rate_threshold: 0.99
+      af_threshold: 0.05
+      hwe_threshold: 0.00001 #1e-5
 
   generate_truthset_ht:
     omni: '${cvars.resdir}/1000G_omni2.5.hg38.vcf.gz'
@@ -173,7 +199,6 @@ step2:
     unrelated_king_file: '${cvars.mtdir}/unrelated_king.mt' # output
     related_king_file: '${cvars.mtdir}/related_king.mt' # output
     kinship_threshold: 0.0442 
-    divergence_threshold: -0.0442
   prune:
     pruned_mt_file: '${cvars.mtdir}/mt_ldpruned.mt' # output
     pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -236,7 +236,12 @@ step2:
   # --- Step 2.3 --- #
   merge_1kg_and_ldprune:
     pruned_mt_outfile: '${cvars.mtdir}/1kg_filtered_ldpruned.mt'
-    r2_threshold: 0.2
+    ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+      r2: 0.2
+      # bp_window_size:
+      # memory_per_core:
+      # keep_higher_maf:
+      # block_size:
     pruned_and_merged_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
 
   pop_pca:

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -200,12 +200,12 @@ step2:
   # --- Step 2.3 --- #
   merge_1kg_and_ldprune:
     long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
-    merged_filtered_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered.mt'
+    pruned_mt_outfile: '${cvars.mtdir}/1kg_filtered_ldpruned.mt'
     call_rate_threshold: 0.99
     af_threshold: 0.05
     hwe_threshold: 0.00001 #1e-5
     r2_threshold: 0.2
-    filtered_and_pruned_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
+    pruned_and_merged_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
 
   pop_pca:
     pca_1kg_scores_file: '${cvars.mtdir}/pop_pca_1kg_scores.ht'

--- a/config/public-dataset.yaml
+++ b/config/public-dataset.yaml
@@ -41,6 +41,7 @@ general:
     #Set batch_file to null if you don't have batch information. All samples will be marked as batch1.
     batch_file:          null #'${general.metadata_dir}/${general.dataset_name}.batch.tsv'
     vep_consequences:    '${general.metadata_dir}/${general.dataset_name}.all_consequences_with_gene_and_csq.tsv.bgz'
+    # Set pedigree to null, if you don't want to run transmitted/untransmitted singletons statistics calculations
     pedigree:            '${general.metadata_dir}/${general.dataset_name}.trios.fam'
     giab_sample_id: 'NA12878'
     # control samples are excluded from sample QC to remain in variant QC
@@ -378,7 +379,8 @@ step3:
 
   # --- Step 3.5 --- #
   add_cq_annotation:
-    synonymous_file: '${cvars.metadir}/${general.dataset_name}.synonymous_variants.tsv.bgz'
+    # Put here `null`, if you don't want to run transmitted/untransmitted singletons statistics calculations
+    cqfile: '${general.metadata.vep_consequences}'
 
   dnm_and_family_annotation:
     dnm_htfile: '${cvars.mtdir}/denovo_table.ht'
@@ -428,7 +430,6 @@ step3:
   # --- Step 3.9 --- #
   annotate_mt_with_cq_rf_score_and_bin:
     mtfile: '${cvars.mtdir}/mt_varqc_splitmulti.mt'
-    cqfile: '${cvars.metadir}/${general.dataset_name}.all_consequences.tsv.bgz'
     mtoutfile_after_varqc: '${cvars.mtdir}/mt_after_var_qc.mt'
 
 
@@ -471,7 +472,10 @@ step4:
   # --- Step 4.2 --- #
   annotate_cq_rf:
     mtfile: '${cvars.mtdir}/mt_varqc_splitmulti.mt'
+    # Put here `null`, if you don't want add VEP consequences annotation
     cqfile: '${general.metadata.vep_consequences}'
+    # Put here `null`, if you don't want add VEP consequences annotation. Othrewise specify to have correct header in the output VCFs
+    csq_header: '${general.metadata_dir}/${general.dataset_name}.csq_header.txt'
 
   apply_hard_filters:
     # Set to true if you want to apply different hard filters for sex chromosomes in male samples (depth threshold will be halfed for sex chromosome).
@@ -521,6 +525,7 @@ step4:
   # used as an output of the whole step
   mtoutfile_annot: '${cvars.mtdir}/mt_hard_filter_combinations.mt'
 
+  
   # --- Step 4.3a --- #
   export_vcfs_a:
     mtfile: '${cvars.mtdir}/mt_hard_filter_combinations.mt'

--- a/tests/integration_tests/config_test_template.yaml
+++ b/tests/integration_tests/config_test_template.yaml
@@ -236,7 +236,12 @@ step2:
   # --- Step 2.3 --- #
   merge_1kg_and_ldprune:
     pruned_mt_outfile: '${cvars.mtdir}/1kg_filtered_ldpruned.mt'
-    r2_threshold: 0.2
+    ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+      r2: 0.2
+      # bp_window_size:
+      # memory_per_core:
+      # keep_higher_maf:
+      # block_size:
     pruned_and_merged_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
 
   pop_pca:
@@ -378,7 +383,7 @@ step3:
   # --- Step 3.5 --- #
   add_cq_annotation:
     # Put here `null`, if you don't want to run transmitted/untransmitted singletons statistics calculations
-    cqfile: null #'${general.metadata.vep_consequences}'
+    cqfile: '${general.metadata.vep_consequences}'
 
   dnm_and_family_annotation:
     dnm_htfile: '${cvars.mtdir}/denovo_table.ht'

--- a/tests/integration_tests/config_test_template.yaml
+++ b/tests/integration_tests/config_test_template.yaml
@@ -292,13 +292,13 @@ step2:
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_qc_metrics_residuals
     compute_qc_metrics_residuals_args: #do not specify strata and regression_sample_inclusion_expr in compute_qc_metrics_residuals_args
-      n_pcs: 10 # Number of PCA components
+      n_pcs: 2 # Number of PCA components. Should be <= pc_components in `pc_relate_params`
 
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     #https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.determine_nearest_neighbors
     determine_nearest_neighbors_args: #do not specify add_neighbor_distances and strata here
-      n_pcs: 10 # Number of PCA components.
-      n_neighbors: 50 # Number of neighbours to calculate average values
+      n_pcs: 2 # Number of PCA components. Should be <= pc_components in `pc_relate_params`
+      n_neighbors: 4 # Number of neighbours to calculate average values
 
     # Additional parameters to pass to gnomAD sampleQC function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_stratified_metrics_filter

--- a/tests/integration_tests/config_test_template.yaml
+++ b/tests/integration_tests/config_test_template.yaml
@@ -38,7 +38,7 @@ general:
   metadata:
     verifybamid_selfsm:  '${general.metadata_dir}/${general.dataset_name}.verify_bam_id_result.selfSM.tsv'  # Set to null if you don't have freemix data
     self_reported_sex:   '${general.metadata_dir}/${general.dataset_name}.self_reported_sex.tsv'
-    #Set batch_file to null if you don't have batch information. All samples will be marked as batch1.
+    # Set batch_file to null if you don't have batch information. All samples will be marked as batch1.
     batch_file:          null #'${general.metadata_dir}/${general.dataset_name}.batch.tsv'
     vep_consequences:    '${general.metadata_dir}/${general.dataset_name}.all_consequences_with_gene_and_csq.tsv.bgz'
     # Set pedigree to null, if you don't want to run transmitted/untransmitted singletons statistics calculations
@@ -46,8 +46,12 @@ general:
     giab_sample_id: 'EGAN00003332049'
     # control samples are excluded from sample QC to remain in variant QC
     control_samples: ['EGAN00003332049']
-
-  rf_model_id: "testhash"
+  # Sample QC method (see the details in docs/wxs-qc_howto.md ):
+  # * pop - Stratified QC with PCA-assigned superpopulations (from gnomAD v3 + de novo PCA projection)
+  # * nn - Nearest neighbours (from gnomAD v4)
+  # * lr - linera regression (from gnomAD v4)
+  sample_qc_method: 'lr'
+  rf_model_id: "testhash" # Random forest model ID for Variant QC
 
 # Block of cvars variables - use to provide shorter alternatives for long names
 cvars:
@@ -166,7 +170,7 @@ step2:
     defined_gt_frac_threshold: 0.99
 
   impute_sex:
-    sex_ht_outfile: '${cvars.anndir}/sex_annotated.sex_check.tsv.bgz'
+    sex_ht_outfile: '${cvars.anndir}/sex_annotated.sex_check.tsv.gz'
     sex_mt_outfile: '${cvars.mtdir}/mt_sex_annotated.mt'
     hail_impute_sex_params:  # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.impute_sex
       female_threshold: 0.4
@@ -274,52 +278,48 @@ step2:
     annotated_mt_file: '${cvars.mtdir}/gatk_unprocessed_with_pop.mt' # output
 
   stratified_sample_qc:
-    sample_qc_method: 'lr' #pop -stratification based on population; nn - nearest neighbours; lm - linear model
+    sample_qc_method: '${general.sample_qc_method}'  # The sampleQC method from general
     ht_qc_cols_outfile: '${cvars.mtdir}/mt_stratified_sampleqc.ht' # output
     qc_filter_file: '${cvars.mtdir}/mt_stratified_QC_filters.ht' # output
     mad_file: '${cvars.mtdir}/mad.ht' # output
     min_depth: 5
     min_genotype_quality: 10
     min_vaf: 0.2
-    # Use batch in nn or lr. True or Falce
+    # Use batch in nn or lr, if it is available. If no batch data is available, this parameters will be automatically set to False
+    # You can set it to `False` if you want to run sampleQC in cross-batch mode
     use_batch: True
 
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_qc_metrics_residuals
     compute_qc_metrics_residuals_args: #do not specify strata and regression_sample_inclusion_expr in compute_qc_metrics_residuals_args
-    #  use_pc_square: True # Optional parmeter. To use default value keep this line commented.
-    #  n_pcs: 10 # Optional parmeter. To use default value keep this line commented.
+      n_pcs: 10 # Number of PCA components
 
     # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
     #https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.determine_nearest_neighbors
-    determine_nearest_neighbors_args: #do not specify add_neighbor_distances and strata in determine_nearest_neighbors_args
-    #  n_pcs: 10 # Optional parmeter. To use default value keep this line commented.
-    #  n_neighbors: 50 # Optional parmeter. To use default value keep this line commented.
-    #  n_jobs: -1 # Optional parmeter. To use default value keep this line commented.
-    #  distance_metric: “euclidean” # Optional parmeter. To use default value keep this line commented.
-    #  use_approximation: False # Optional parmeter. To use default value keep this line commented.
-    #  n_trees: 10 # Optional parmeter. To use default value keep this line commented.
+    determine_nearest_neighbors_args: #do not specify add_neighbor_distances and strata here
+      n_pcs: 10 # Number of PCA components.
+      n_neighbors: 50 # Number of neighbours to calculate average values
 
     # Additional parameters to pass to gnomAD sampleQC function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_stratified_metrics_filter
     compute_stratified_metrics_filter_args: #do not specify comparison_sample_expr in compute_stratified_metrics_filter_args
       lower_threshold: 4.0 # Using a broad interval to make all samples pass QC
       upper_threshold: 4.0
-    #  metric_threshold: {'r_het_hom_var': [math.inf, 4.0], 'heterozygosity_rate': [math.inf, 4.0]} # Optional parmeter. To use default value keep this line commented.
+    #  metric_threshold: {'r_het_hom_var': [math.inf, 4.0], 'heterozygosity_rate': [math.inf, 4.0]} # Per-metric MAD thresholds
     # extra output files
-    output_text_file: '${cvars.anndir}/stratified_sample_qc.tsv.bgz' # output
-    output_stratified_metrics_json_file: '${cvars.anndir}/stratified_sample_qc.qc_metrics_stats.json' # output
-    output_nn_file: '${cvars.anndir}/nearest_neighbours.tsv.bgz' # output
-    output_residuals_file: '${cvars.anndir}/residuals.tsv.bgz' # output
+    output_text_file: '${cvars.anndir}/stratified_sample_qc.${general.sample_qc_method}.tsv.gz' # output
+    output_stratified_metrics_json_file: '${cvars.anndir}/stratified_sample_qc.${general.sample_qc_method}.qc_metrics_stats.json' # output
+    output_nn_file: '${cvars.anndir}/nearest_neighbours.tsv.gz' # output
+    output_residuals_file: '${cvars.anndir}/residuals.tsv.gz' # output
     output_lms_json_file: '${cvars.anndir}/lms.json' # output
 
   plot_sample_qc_metrics:
     n_bins: 4
-    plot_outdir: '${cvars.pltdir}/stratified_sample_qc_metrics'
+    plot_outdir: '${cvars.pltdir}/stratified_sample_qc_metrics_${general.sample_qc_method}'
 
   # --- Step 2.5 --- #
   remove_sample_qc_fails:
-    samples_failing_qc_file: '${cvars.anndir}/samples_failing_qc.tsv.bgz'
+    samples_failing_qc_file: '${cvars.anndir}/samples_failing_qc.${general.sample_qc_method}.tsv'
     sample_qc_filtered_mt_file: '${cvars.mtdir}/mt_pops_QC_filters_after_sample_qc.mt'
 
   sample_qc_combine_results:

--- a/tests/integration_tests/config_test_template.yaml
+++ b/tests/integration_tests/config_test_template.yaml
@@ -38,9 +38,14 @@ general:
   metadata:
     verifybamid_selfsm:  '${general.metadata_dir}/${general.dataset_name}.verify_bam_id_result.selfSM.tsv'  # Set to null if you don't have freemix data
     self_reported_sex:   '${general.metadata_dir}/${general.dataset_name}.self_reported_sex.tsv'
-    vep_consequences:   '${general.metadata_dir}/${general.dataset_name}.all_consequences_with_gene_and_csq.tsv.bgz'
-    pedigree:           {PEDIGREE_FILE_NAME} # Set to null if you don't have trios
-    giab_sample_id: 'EGAN00003332049' # Set to null if you don't have control samples
+    #Set batch_file to null if you don't have batch information. All samples will be marked as batch1.
+    batch_file:          null #'${general.metadata_dir}/${general.dataset_name}.batch.tsv'
+    vep_consequences:    '${general.metadata_dir}/${general.dataset_name}.all_consequences_with_gene_and_csq.tsv.bgz'
+    # Set pedigree to null, if you don't want to run transmitted/untransmitted singletons statistics calculations
+    pedigree:            {PEDIGREE_FILE_NAME} # Set to null if you don't have trios
+    giab_sample_id: 'EGAN00003332049'
+    # control samples are excluded from sample QC to remain in variant QC
+    control_samples: ['EGAN00003332049']
 
   rf_model_id: "testhash"
 
@@ -65,24 +70,44 @@ step0:
     vcfheader: '${general.onekg_resource_dir}/header_20201028.txt' # not available for the test data, this parameter is ignored
     kg_pop_file: '${cvars.resdir}/igsr_samples.tsv'
     kg_unprocessed: '${cvars.mtdir}/kg_unprocessed.mt'
-    pruned_kg_file: '${cvars.mtdir}/kg_pruned_ld.mt'
+    filtered_kg_file: '${cvars.mtdir}/kg_filtered.mt'
     long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
-    relatedness_ht_file: '${cvars.mtdir}/kg_relatedness.ht'
     samples_to_remove_file: '${cvars.mtdir}/kg_related_samples_to_remove.ht'
-    scores_file: '${cvars.mtdir}/kg_pruned.pca_scores.ht'
+    filter_params:
+      call_rate_threshold: 0.99
+      af_threshold: 0.05
+      hwe_threshold: 0.00001 #1e-5
+
+    king_params:
+      king_output_file: '${cvars.mtdir}/king_kg.ht'
+      unrelated_king_file: '${cvars.mtdir}/unrelated_kg_king.mt' # output
+      related_king_file: '${cvars.mtdir}/related_kg_king.mt' # output
+      kinship_threshold: 0.0442
+    prune_params:
+      pruned_mt_file: '${cvars.mtdir}/kg_pruned_ld.mt' # output
+      ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+        r2: 0.2
+        # bp_window_size:
+        # memory_per_core:
+        # keep_higher_maf:
+        # block_size:
+
+    pc_relate_params:
+      unrelated_samples_scores_file: '${cvars.mtdir}/kg.king_unrelated_samples.pca_scores.ht' # output
+      pca_loadings_file_pc_relate: '${cvars.mtdir}/kg.king_unrelated_samples.pca_loadings.ht' # output
+      scores_file: '${cvars.mtdir}/kg_filtered.pca_scores.ht'
+      pca_components: 10
+      pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
+        min_individual_maf: 0.05
+        block_size: 4096
+        min_kinship: 0.05
+        statistics: 'kin2'
+        # k:
+        # include_self_kinship:
+      relatedness_column: 'kin'
+      relatedness_threshold: 0.125
 
     kg_out_mt: '${cvars.mtdir}/kg_wes_regions.mt' # output
-    call_rate_threshold: 0.99
-    af_threshold: 0.05
-    hwe_threshold: 0.00001 #1e-5
-    r2_threshold: 0.2
-    hl_pc_related_kwargs:
-      min_individual_maf: 0.05
-      block_size: 4096
-      min_kinship: 0.05
-      statistics: "kin2"
-    pca_components: 10
-    kin_threshold: 0.125
 
   generate_truthset_ht:
     omni: '${cvars.resdir}/1000G_omni2.5.hg38.vcf.gz'
@@ -108,9 +133,10 @@ step1:
     verifybamid_plot: '${cvars.pltdir}/freemix_validation.html'
     samples_failing_freemix_tsv: '${cvars.anndir}/samples_failing_freemix.tsv'
     freemix_treshold: 0.05
-    remove_freemix_outliers: false
+    remove_freemix_outliers: true
 
   sex_metadata_file: ${general.metadata.self_reported_sex}
+  batch_metadata_file: ${general.metadata.batch_file}
   mt_metadata_annotated: '${cvars.mtdir}/mt_metadata_annotated.mt'
 
   # --- Step 1.3 --- #
@@ -157,7 +183,18 @@ step2:
     conflicting_sex_report_file: '${cvars.anndir}/conflicting_sex.tsv' # output
 
   # --- Step 2.2 --- #
-  prune:
+  long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
+  filter_params:
+    call_rate_threshold: 0.99
+    af_threshold: 0.05
+    hwe_threshold: 0.00001 #1e-5
+  filtered_mt_outfile: '${cvars.mtdir}/filtered_for_PCA.mt'
+  king_params:
+    king_output_file: '${cvars.mtdir}/king.ht'
+    unrelated_king_file: '${cvars.mtdir}/unrelated_king.mt' # output
+    related_king_file: '${cvars.mtdir}/related_king.mt' # output
+    kinship_threshold: 0.0442
+  prune_params:
     pruned_mt_file: '${cvars.mtdir}/mt_ldpruned.mt' # output
     ld_prune_args: # https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
       r2: 0.2
@@ -165,12 +202,11 @@ step2:
       # memory_per_core:
       # keep_higher_maf:
       # block_size:
-
-  prune_pc_relate:
+  pc_relate_params:
+    unrelated_samples_scores_file: '${cvars.mtdir}/mt_pruned.unrelated_samples.pca_scores.ht' # output
+    pca_loadings_file_pc_relate: '${cvars.mtdir}/mt_pruned.pca_loadings.ht' # output
     scores_file: '${cvars.mtdir}/mt_pruned.pca_scores.ht' # output
-    samples_to_remove_file: '${cvars.mtdir}/mt_related_samples_to_remove.ht' # output
-    samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
-    pca_components: 3
+    pca_components: 10
     pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
       min_individual_maf: 0.05
       block_size: 4096
@@ -180,33 +216,35 @@ step2:
       # include_self_kinship:
     relatedness_column: 'kin'
     relatedness_threshold: 0.125
+
+  relatedness_output:
     relatedness_outfile: '${cvars.anndir}/relatedness.tsv.gz'
     relatedness_plotfile: '${cvars.pltdir}/relatedness_plot.html'
+    samples_to_remove_file: '${cvars.mtdir}/mt_related_samples_to_remove.ht' # output
+    samples_to_remove_tsv: '${cvars.anndir}/related_samples_to_remove.tsv' # output in the TSV table
 
   prune_plot_pca:
-    plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
-    pca_components: 4
-    pca_scores_file: '${cvars.mtdir}/mt_pca_scores.ht' # output
-    pca_loadings_file: '${cvars.mtdir}/mt_pca_loadings.ht' # output
+    #plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
+    pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output
+    pca_components: 10
+    union_pca_scores_file: '${cvars.mtdir}/mt_pca_scores.ht' # output
+    pca_scores_file: '${cvars.mtdir}/mt_pca_scores.unrelated_samples.ht' # output
+    pca_loadings_file: '${cvars.mtdir}/mt_pca_loadings.unrelated_samples.ht' # output
     pca_mt_file: '${cvars.mtdir}/mt_pca.mt' # output
-    plot_outfile: '${cvars.pltdir}/pca.html' # output
+    plot_outfile: '${cvars.pltdir}/relatedness_pca.html' # output
 
   # --- Step 2.3 --- #
   merge_1kg_and_ldprune:
-    long_range_ld_file: '${cvars.resdir}/long_ld_regions.hg38.bed'
-    merged_filtered_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered.mt'
-    call_rate_threshold: 0.99
-    af_threshold: 0.05
-    hwe_threshold: 0.00001 #1e-5
+    pruned_mt_outfile: '${cvars.mtdir}/1kg_filtered_ldpruned.mt'
     r2_threshold: 0.2
-    filtered_and_pruned_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
+    pruned_and_merged_mt_outfile: '${cvars.mtdir}/merged_with_1kg_filtered_ldpruned.mt'
 
   pop_pca:
     pca_1kg_scores_file: '${cvars.mtdir}/pop_pca_1kg_scores.ht'
     pca_1kg_loadings_file: '${cvars.mtdir}/pop_pca_1kg_loadings.ht'
     pca_1kg_evals_file: '${cvars.anndir}/pop_pca_1kg_evals.tsv'
     pca_union_scores_file: '${cvars.mtdir}/pop_pca_union_scores.ht'
-    pca_components: 4
+    pca_components: 10
 
   plot_pop_pca:
     pca_components: 3
@@ -231,23 +269,48 @@ step2:
     annotated_mt_file: '${cvars.mtdir}/gatk_unprocessed_with_pop.mt' # output
 
   stratified_sample_qc:
-    mt_qc_outfile: '${cvars.mtdir}/mt_pops_sampleqc.mt' # output
-    ht_qc_cols_outfile: '${cvars.mtdir}/mt_pops_sampleqc.ht' # output
-    qc_filter_file: '${cvars.mtdir}/mt_pops_QC_filters.ht' # output
+    sample_qc_method: 'lr' #pop -stratification based on population; nn - nearest neighbours; lm - linear model
+    ht_qc_cols_outfile: '${cvars.mtdir}/mt_stratified_sampleqc.ht' # output
+    qc_filter_file: '${cvars.mtdir}/mt_stratified_QC_filters.ht' # output
+    mad_file: '${cvars.mtdir}/mad.ht' # output
     min_depth: 5
     min_genotype_quality: 10
     min_vaf: 0.2
+    # Use batch in nn or lr. True or Falce
+    use_batch: True
+
+    # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
+    # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_qc_metrics_residuals
+    compute_qc_metrics_residuals_args: #do not specify strata and regression_sample_inclusion_expr in compute_qc_metrics_residuals_args
+    #  use_pc_square: True # Optional parmeter. To use default value keep this line commented.
+    #  n_pcs: 10 # Optional parmeter. To use default value keep this line commented.
+
+    # Additional parameters to pass to gnomAD determine_nearest_neighbors function:
+    #https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.determine_nearest_neighbors
+    determine_nearest_neighbors_args: #do not specify add_neighbor_distances and strata in determine_nearest_neighbors_args
+    #  n_pcs: 10 # Optional parmeter. To use default value keep this line commented.
+    #  n_neighbors: 50 # Optional parmeter. To use default value keep this line commented.
+    #  n_jobs: -1 # Optional parmeter. To use default value keep this line commented.
+    #  distance_metric: “euclidean” # Optional parmeter. To use default value keep this line commented.
+    #  use_approximation: False # Optional parmeter. To use default value keep this line commented.
+    #  n_trees: 10 # Optional parmeter. To use default value keep this line commented.
+
     # Additional parameters to pass to gnomAD sampleQC function:
     # https://broadinstitute.github.io/gnomad_methods/api_reference/sample_qc/filtering.html#gnomad.sample_qc.filtering.compute_stratified_metrics_filter
-    compute_stratified_metrics_filter_args:
-      lower_threshold: 12.0 # Using a broad interval to make all samples pass QC
-      upper_threshold: 12.0
-    output_text_file: '${cvars.anndir}/sample_qc_by_pop.tsv.bgz' # output
-    output_globals_json_file: '${cvars.anndir}/sample_qc_by_pop.globals.json' # output
+    compute_stratified_metrics_filter_args: #do not specify comparison_sample_expr in compute_stratified_metrics_filter_args
+      lower_threshold: 4.0 # Using a broad interval to make all samples pass QC
+      upper_threshold: 4.0
+    #  metric_threshold: {'r_het_hom_var': [math.inf, 4.0], 'heterozygosity_rate': [math.inf, 4.0]} # Optional parmeter. To use default value keep this line commented.
+    # extra output files
+    output_text_file: '${cvars.anndir}/stratified_sample_qc.tsv.bgz' # output
+    output_stratified_metrics_json_file: '${cvars.anndir}/stratified_sample_qc.qc_metrics_stats.json' # output
+    output_nn_file: '${cvars.anndir}/nearest_neighbours.tsv.bgz' # output
+    output_residuals_file: '${cvars.anndir}/residuals.tsv.bgz' # output
+    output_lms_json_file: '${cvars.anndir}/lms.json' # output
 
   plot_sample_qc_metrics:
     n_bins: 4
-    plot_outdir: '${cvars.pltdir}/sample_qc_metrics'
+    plot_outdir: '${cvars.pltdir}/stratified_sample_qc_metrics'
 
   # --- Step 2.5 --- #
   remove_sample_qc_fails:
@@ -314,7 +377,8 @@ step3:
 
   # --- Step 3.5 --- #
   add_cq_annotation:
-    synonymous_file: '${cvars.metadir}/${general.dataset_name}.synonymous_variants.tsv.bgz'
+    # Put here `null`, if you don't want to run transmitted/untransmitted singletons statistics calculations
+    cqfile: '${general.metadata.vep_consequences}'
 
   dnm_and_family_annotation:
     dnm_htfile: '${cvars.mtdir}/denovo_table.ht'
@@ -364,7 +428,6 @@ step3:
   # --- Step 3.9 --- #
   annotate_mt_with_cq_rf_score_and_bin:
     mtfile: '${cvars.mtdir}/mt_varqc_splitmulti.mt'
-    cqfile: '${cvars.metadir}/${general.dataset_name}.all_consequences.tsv.bgz'
     mtoutfile_after_varqc: '${cvars.mtdir}/mt_after_var_qc.mt'
 
 
@@ -407,9 +470,16 @@ step4:
   # --- Step 4.2 --- #
   annotate_cq_rf:
     mtfile: '${cvars.mtdir}/mt_varqc_splitmulti.mt'
+    # Put here `null`, if you don't want add VEP consequences annotation
     cqfile: '${general.metadata.vep_consequences}'
+    # Put here `null`, if you don't want add VEP consequences annotation. Othrewise specify to have correct header in the output VCFs
+    csq_header: '${general.metadata_dir}/${general.dataset_name}.csq_header.txt'
 
   apply_hard_filters:
+    # Set to true if you want to apply different hard filters for sex chromosomes in male samples (depth threshold will be halfed for sex chromosome).
+    sex_chromosome_specific_filtering: True
+    # A file similar to self_reported_sex with resolved annotation conflicts. This file is used when sex_chromosome_specific_filtering is true
+    sex_annotation_file: '${general.metadata_dir}/${general.dataset_name}.self_reported_sex.tsv'
     hard_filters:
       snp:
         relaxed:
@@ -452,6 +522,7 @@ step4:
 
   # used as an output of the whole step
   mtoutfile_annot: '${cvars.mtdir}/mt_hard_filter_combinations.mt'
+
 
   # --- Step 4.3a --- #
   export_vcfs_a:

--- a/tests/integration_tests/config_test_template.yaml
+++ b/tests/integration_tests/config_test_template.yaml
@@ -206,7 +206,7 @@ step2:
     unrelated_samples_scores_file: '${cvars.mtdir}/mt_pruned.unrelated_samples.pca_scores.ht' # output
     pca_loadings_file_pc_relate: '${cvars.mtdir}/mt_pruned.pca_loadings.ht' # output
     scores_file: '${cvars.mtdir}/mt_pruned.pca_scores.ht' # output
-    pca_components: 10
+    pca_components: 2
     pc_relate_args: # https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate
       min_individual_maf: 0.05
       block_size: 4096
@@ -226,7 +226,7 @@ step2:
   prune_plot_pca:
     #plink_outfile: '${cvars.anndir}/mt_unrelated.plink'
     pruned_unrelated_pcrelate_file: '${cvars.mtdir}/mt_unrelated_ldpruned_pcrelate.mt' # output
-    pca_components: 10
+    pca_components: 2
     union_pca_scores_file: '${cvars.mtdir}/mt_pca_scores.ht' # output
     pca_scores_file: '${cvars.mtdir}/mt_pca_scores.unrelated_samples.ht' # output
     pca_loadings_file: '${cvars.mtdir}/mt_pca_loadings.unrelated_samples.ht' # output
@@ -378,7 +378,7 @@ step3:
   # --- Step 3.5 --- #
   add_cq_annotation:
     # Put here `null`, if you don't want to run transmitted/untransmitted singletons statistics calculations
-    cqfile: '${general.metadata.vep_consequences}'
+    cqfile: null #'${general.metadata.vep_consequences}'
 
   dnm_and_family_annotation:
     dnm_htfile: '${cvars.mtdir}/denovo_table.ht'

--- a/tests/integration_tests/integration_stub.py
+++ b/tests/integration_tests/integration_stub.py
@@ -347,7 +347,8 @@ class IntegrationTestsStub(HailTestCase):
         except Exception as e:
             self.fail(f"Step 4.3a failed with an exception: {e}")
 
-    def stub_4_3b_genotype_qc(self):
+    @patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(filter_level="stringent"))
+    def stub_4_3b_genotype_qc(self, mock_args):
         qc_step_4_3b = importlib.import_module("4-genotype_qc.3b-export_vcfs_stringent_filters")
         try:
             qc_step_4_3b.main()

--- a/tests/test_files_list_in_bucket.txt
+++ b/tests/test_files_list_in_bucket.txt
@@ -11,6 +11,7 @@
 ./metadata/control_set_small.trios.fam
 ./metadata/control_set_small.trios-withparents.fam
 ./metadata/control_set_small.verify_bam_id_result.selfSM.tsv
+./metadata/control_set_small.csq_header.txt
 ./metadata/HG001_twistedexome_1kg.bed
 # Small control set VCFs
 ./control_set_small/control_set_small_chr1.vcf.bgz

--- a/wes_qc/compute_relatedness.py
+++ b/wes_qc/compute_relatedness.py
@@ -34,7 +34,7 @@ def prune_pc_relate(
     #Running KING
     related_mt, unrelated_mt = run_king(mt, king_params, prune_params)
     #Running PCA
-    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pc_relate_params["pca_components"])
+    union_pca_scores, pca_scores, pca_loadings, _ = run_pc_project(unrelated_mt, related_mt, pc_relate_params["pca_components"])
     union_pca_scores=union_pca_scores.checkpoint(path_spark(pc_relate_params["scores_file"]), overwrite=True)
     pca_scores=pca_scores.checkpoint(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
     pca_loadings=pca_loadings.checkpoint(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)

--- a/wes_qc/compute_relatedness.py
+++ b/wes_qc/compute_relatedness.py
@@ -1,8 +1,10 @@
-#Identical
 from utils.utils import path_spark
 from wes_qc.pca_utils import prune_mt, run_pc_project
 
 def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
+    '''
+    Separate related and unrelated samples using the KING kinship estimator.
+    '''
     print("=== LD pruning before KING")
     pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
     pruned_mt=pruned_mt.checkpoint(path_spark(prune_args["pruned_mt_file"]), overwrite=True)
@@ -24,7 +26,10 @@ def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.Matri
 
 def prune_pc_relate(
     mt: hl.MatrixTable, prune_params: dict, king_params: dict, pc_relate_params: dict, dataset: str, **kwargs
-) -> (hl.Table, hl.Table, hl.Table, hl.Table, hl.Table):
+) -> (hl.Table, hl.Table):
+    '''
+    Complete PC-Relate workflow for identifying and removing related samples.
+    '''
     #Running KING
     related_mt, unrelated_mt = run_king(mt, king_params, prune_params)
     #Running PCA
@@ -32,7 +37,6 @@ def prune_pc_relate(
     union_pca_scores=union_pca_scores.checkpoint(path_spark(pc_relate_params["scores_file"]), overwrite=True)
     pca_scores=pca_scores.checkpoint(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
     pca_loadings=pca_loadings.checkpoint(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)
-    print("=== Calculating relatedness")
     if dataset == "study":
         related_mt = related_mt.drop(#For some reason unrelated_mt doesn't have these in study data
             "AD",
@@ -47,6 +51,8 @@ def prune_pc_relate(
             "RGQ"
         )
     pruned_mt = related_mt.union_cols(unrelated_mt)
+    print("=== Calculating relatedness")
+    #calculate relatedness using PC relate
     relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_params["pc_relate_args"])
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
     pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)

--- a/wes_qc/compute_relatedness.py
+++ b/wes_qc/compute_relatedness.py
@@ -1,3 +1,4 @@
+import hail as hl
 from utils.utils import path_spark
 from wes_qc.pca_utils import prune_mt, run_pc_project
 

--- a/wes_qc/compute_relatedness.py
+++ b/wes_qc/compute_relatedness.py
@@ -1,0 +1,55 @@
+#Identical
+from utils.utils import path_spark
+from wes_qc.pca_utils import prune_mt, run_pc_project
+
+def run_king(mt: hl.MatrixTable, king_args: dict, prune_args: dict) -> (hl.MatrixTable, hl.MatrixTable):
+    print("=== LD pruning before KING")
+    pruned_mt= prune_mt(mt, prune_args["ld_prune_args"])
+    pruned_mt=pruned_mt.checkpoint(path_spark(prune_args["pruned_mt_file"]), overwrite=True)
+    print("=== Running KING")
+    king_mt = hl.king(pruned_mt.GT)
+    king_ht=king_mt.entries()
+    king_ht=king_ht.checkpoint(path_spark(king_args["king_output_file"]), overwrite=True)
+    related_pairs_ht = king_ht.filter((king_ht.phi > king_args["kinship_threshold"]) & (king_ht.s_1!=king_ht.s))
+    print("=== Identifying related samples")
+    samples_to_remove=hl.maximal_independent_set(related_pairs_ht.s_1, related_pairs_ht.s, keep=False)
+    unrelated_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]), keep=False)
+    related_mt = mt.filter_cols(hl.is_defined(samples_to_remove[mt.col_key]))
+    print("=== LD pruning unrelated samples")
+    pruned_unrelated_mt = prune_mt(unrelated_mt, prune_args["ld_prune_args"])
+    pruned_unrelated_mt=pruned_unrelated_mt.checkpoint(path_spark(king_args["unrelated_king_file"]), overwrite=True)
+    related_mt = related_mt.semi_join_rows(pruned_unrelated_mt.rows())
+    related_mt=related_mt.checkpoint(path_spark(king_args["related_king_file"]), overwrite=True)
+    return related_mt, pruned_unrelated_mt
+
+def prune_pc_relate(
+    mt: hl.MatrixTable, prune_params: dict, king_params: dict, pc_relate_params: dict, dataset: str, **kwargs
+) -> (hl.Table, hl.Table, hl.Table, hl.Table, hl.Table):
+    #Running KING
+    related_mt, unrelated_mt = run_king(mt, king_params, prune_params)
+    #Running PCA
+    union_pca_scores, pca_scores, pca_loadings = run_pc_project(unrelated_mt, related_mt, pc_relate_params["pca_components"])
+    union_pca_scores=union_pca_scores.checkpoint(path_spark(pc_relate_params["scores_file"]), overwrite=True)
+    pca_scores=pca_scores.checkpoint(path_spark(pc_relate_params["unrelated_samples_scores_file"]), overwrite=True)
+    pca_loadings=pca_loadings.checkpoint(path_spark(pc_relate_params["pca_loadings_file_pc_relate"]), overwrite=True)
+    print("=== Calculating relatedness")
+    if dataset == "study":
+        related_mt = related_mt.drop(#For some reason unrelated_mt doesn't have these in study data
+            "AD",
+            "DP",
+            "GQ",
+            "MIN_DP",
+            "PGT",
+            "PID",
+            "PL",
+            "PS",
+            "SB",
+            "RGQ"
+        )
+    pruned_mt = related_mt.union_cols(unrelated_mt)
+    relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_params["pc_relate_args"])
+    # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
+    pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)
+    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
+    return related_samples_to_remove, relatedness_ht
+

--- a/wes_qc/compute_relatedness.py
+++ b/wes_qc/compute_relatedness.py
@@ -56,7 +56,7 @@ def prune_pc_relate(
     #calculate relatedness using PC relate
     relatedness_ht = hl.pc_relate(pruned_mt.GT, scores_expr=union_pca_scores[pruned_mt.col_key].scores, **pc_relate_params["pc_relate_args"])
     # prune individuals to be left with unrelated - creates a table containing one column - samples to remove
-    pairs = relatedness_ht.filter(relatedness_ht[relatedness_column] > relatedness_threshold)
+    pairs = relatedness_ht.filter(relatedness_ht[pc_relate_params["relatedness_column"]] > pc_relate_params["relatedness_threshold"])
     related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, keep=False)
     return related_samples_to_remove, relatedness_ht
 

--- a/wes_qc/filtering.py
+++ b/wes_qc/filtering.py
@@ -3,6 +3,7 @@ All fucntions used to filter samples/variants
 """
 
 import hail as hl
+from utils.utils import path_spark
 
 from wes_qc import hail_patches
 
@@ -87,7 +88,7 @@ def filter_vars_for_quality(
 
 def remove_ld_regions(mt: hl.MatrixTable, long_range_ld_file: str) -> hl.MatrixTable:
     # remove long ld regions
-    long_range_ld_to_exclude = hl.import_bed(long_range_ld_file, reference_genome="GRCh38")
+    long_range_ld_to_exclude = hl.import_bed(path_spark(long_range_ld_file), reference_genome="GRCh38")
     mt = mt.filter_rows(hl.is_defined(long_range_ld_to_exclude[mt.locus]), keep=False)
     return mt
 

--- a/wes_qc/pca_utils.py
+++ b/wes_qc/pca_utils.py
@@ -30,5 +30,5 @@ def run_pc_project(mt_ref, mt_study, pca_components):
     projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
     union_pca_scores = pca_scores.union(projection_pca_scores)
 
-    return union_pca_scores, pca_scores, pca_loadings
+    return union_pca_scores, pca_scores, pca_loadings, pca_evals
 

--- a/wes_qc/pca_utils.py
+++ b/wes_qc/pca_utils.py
@@ -1,3 +1,4 @@
+import hail as hl
 from wes_qc import hail_patches
 from gnomad.sample_qc.ancestry import pc_project
 

--- a/wes_qc/pca_utils.py
+++ b/wes_qc/pca_utils.py
@@ -2,19 +2,9 @@ from wes_qc import hail_patches
 from gnomad.sample_qc.ancestry import pc_project
 
 def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
-    """
-    Splits multiallelic sites and runs ld pruning
-    Filter to autosomes before LD pruning to decrease sample size - autosomes only wanted for later steps
-    :param MatrixTable mt: input MT containing variants to be pruned
-    :param dict config:
-    :return: Pruned MatrixTable
-    :rtype: hl.MatrixTable
-
-    `hl.ld_prune` returns a maximal subset of variants that are nearly uncorrelated within each window.
-    Requires the dataset to contain only diploid genotype calls and no multiallelic variants.
-    See also: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
-    """
-
+    '''
+    Prune variants in linkage disequilibrium (LD) on autosomes.
+    '''
     print("=== Filtering to autosomes")
     mt = mt.filter_rows(mt.locus.in_autosome())
     print("=== Splitting multiallelic sites")
@@ -28,6 +18,9 @@ def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
     return pruned_mt
 
 def run_pc_project(mt_ref, mt_study, pca_components):
+    '''
+    Run PCA on reference data and project study samples onto the PC space.
+    '''
     print("=== Running PCA")
     pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
     pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()

--- a/wes_qc/pca_utils.py
+++ b/wes_qc/pca_utils.py
@@ -1,0 +1,40 @@
+from wes_qc import hail_patches
+from gnomad.sample_qc.ancestry import pc_project
+
+def prune_mt(mt: hl.MatrixTable, ld_prune_args, **kwargs) -> hl.MatrixTable:
+    """
+    Splits multiallelic sites and runs ld pruning
+    Filter to autosomes before LD pruning to decrease sample size - autosomes only wanted for later steps
+    :param MatrixTable mt: input MT containing variants to be pruned
+    :param dict config:
+    :return: Pruned MatrixTable
+    :rtype: hl.MatrixTable
+
+    `hl.ld_prune` returns a maximal subset of variants that are nearly uncorrelated within each window.
+    Requires the dataset to contain only diploid genotype calls and no multiallelic variants.
+    See also: https://hail.is/docs/0.2/methods/genetics.html#hail.methods.ld_prune
+    """
+
+    print("=== Filtering to autosomes")
+    mt = mt.filter_rows(mt.locus.in_autosome())
+    print("=== Splitting multiallelic sites")
+    mt = hail_patches.split_multi_hts(
+        mt, recalculate_gq=False
+    )  # this shouldn't do anything as only biallelic sites are used
+    print("=== Performing LD pruning")
+    pruned_ht = hl.ld_prune(mt.GT, **ld_prune_args)
+    pruned_mt = mt.filter_rows(hl.is_defined(pruned_ht[mt.row_key]))
+    pruned_mt = pruned_mt.select_entries(GT=hl.unphased_diploid_gt_index_call(pruned_mt.GT.n_alt_alleles()))
+    return pruned_mt
+
+def run_pc_project(mt_ref, mt_study, pca_components):
+    print("=== Running PCA")
+    pca_evals, pca_scores, pca_loadings = hl.hwe_normalized_pca(mt_ref.GT, k=pca_components, compute_loadings=True)
+    pca_af_ht = mt_ref.annotate_rows(pca_af=hl.agg.mean(mt_ref.GT.n_alt_alleles()) / 2).rows()
+    pca_loadings = pca_loadings.annotate(pca_af=pca_af_ht[pca_loadings.key].pca_af)
+    print("=== Running PC projection")
+    projection_pca_scores = pc_project(mt_study, pca_loadings, loading_location="loadings", af_location="pca_af")
+    union_pca_scores = pca_scores.union(projection_pca_scores)
+
+    return union_pca_scores, pca_scores, pca_loadings
+

--- a/wes_qc/vcf_utils.py
+++ b/wes_qc/vcf_utils.py
@@ -1,31 +1,5 @@
-def modify_vcf_metadata(metadata: dict, csq_file: Optional[str] = None, header_file: Optional[str] = None) -> dict:
-    """
-    Modify metadata to include information about the CSQ annotation file and header file used for VCF export.
-    """
-    if header_file is not None and csq_file is not None:
-        metadata=extract_csq_header(header_file, metadata)
-        if not metadata["info"].get("CSQ"):
-                mt = mt.drop(mt.CSQ)
-    if csq_file is not None:
-        metadata["info"].update({
-            "consequence": {
-                "Description": "Most severe consequence from VEP",
-                "Number": "A",
-                "Type": "String",
-            },
-            "gene": {
-                "Description": "Gene affected by the most severe consequence from VEP",
-                "Number": "A",
-                "Type": "String",
-            },
-            "hgnc_id": {
-                "Description": "HGNC id of the gene affected by the most severe consequence from VEP",
-                "Number": "A",
-                "Type": "String",
-            }
-        })
-    return metadata
-
+from typing import Optional
+import re
 def extract_csq_header(header_file: str, metadata: dict) -> dict:
     """
     Modify metadata to include the CSQ description used for VCF export.
@@ -51,4 +25,31 @@ def extract_csq_header(header_file: str, metadata: dict) -> dict:
             "Number": info["Number"],
             "Type": info["Type"],
         }
+    return metadata
+
+def modify_vcf_metadata(metadata: dict, csq_file: Optional[str] = None, header_file: Optional[str] = None) -> dict:
+    """
+    Modify metadata to include information about the CSQ annotation file and header file used for VCF export.
+    """
+    if header_file is not None and csq_file is not None:
+        metadata=extract_csq_header(header_file, metadata)
+    elif csq_file is not None and header_file is None:
+        print("===No CSQ header found. CSQ won't be added to the VCFs===")
+        metadata["info"].update({
+            "consequence": {
+                "Description": "Most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            },
+            "gene": {
+                "Description": "Gene affected by the most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            },
+            "hgnc_id": {
+                "Description": "HGNC id of the gene affected by the most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            }
+        })
     return metadata

--- a/wes_qc/vcf_utils.py
+++ b/wes_qc/vcf_utils.py
@@ -1,0 +1,59 @@
+def modify_vcf_metadata(metadata: dict, csq_file: Optional[str] = None, header_file: Optional[str] = None) -> dict:
+    """
+    Modify metadata to include information about the CSQ annotation file and header file used for VCF export.
+    
+    Args:
+        metadata (dict): The original metadata dictionary.
+        csq_file (Optional[str]): The path to the CSQ annotation file used for VCF export.
+        header_file (Optional[str]): The path to the header file used for VCF export.
+    
+    Returns:
+        dict: The modified metadata dictionary with CSQ annotation and header file information added.
+    """
+    if header_file is not None and csq_file is not None:
+        metadata=extract_csq_header(header_file, metadata)
+        if not metadata["info"].get("CSQ"):
+                mt = mt.drop(mt.CSQ)
+    if csq_file is not None:
+        metadata["info"].update({
+            "consequence": {
+                "Description": "Most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            },
+            "gene": {
+                "Description": "Gene affected by the most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            },
+            "hgnc_id": {
+                "Description": "HGNC id of the gene affected by the most severe consequence from VEP",
+                "Number": "A",
+                "Type": "String",
+            }
+        })
+    return metadata
+
+def extract_csq_header(header_file: str, metadata: dict) -> dict:
+    info={}
+    with open(header_file) as f:
+        for line in f:
+            if line.startswith("##INFO=<ID=CSQ"):
+                pattern = re.compile(
+                r'ID=(?P<ID>[^,]+),'
+                r'Number=(?P<Number>[^,]+),'
+                r'Type=(?P<Type>[^,]+),'
+                r'Description="(?P<Description>.*)"'
+                )
+                match = pattern.search(line)
+                info = match.groupdict()
+
+    if len(info) == 0:
+        print("===No CSQ header found. CSQ won't be added to the VCFs===")
+    else:
+        metadata["info"]["CSQ"] = {
+            "Description": info["Description"],
+            "Number": info["Number"],
+            "Type": info["Type"],
+        }
+    return metadata

--- a/wes_qc/vcf_utils.py
+++ b/wes_qc/vcf_utils.py
@@ -1,14 +1,6 @@
 def modify_vcf_metadata(metadata: dict, csq_file: Optional[str] = None, header_file: Optional[str] = None) -> dict:
     """
     Modify metadata to include information about the CSQ annotation file and header file used for VCF export.
-    
-    Args:
-        metadata (dict): The original metadata dictionary.
-        csq_file (Optional[str]): The path to the CSQ annotation file used for VCF export.
-        header_file (Optional[str]): The path to the header file used for VCF export.
-    
-    Returns:
-        dict: The modified metadata dictionary with CSQ annotation and header file information added.
     """
     if header_file is not None and csq_file is not None:
         metadata=extract_csq_header(header_file, metadata)
@@ -35,6 +27,9 @@ def modify_vcf_metadata(metadata: dict, csq_file: Optional[str] = None, header_f
     return metadata
 
 def extract_csq_header(header_file: str, metadata: dict) -> dict:
+    """
+    Modify metadata to include the CSQ description used for VCF export.
+    """
     info={}
     with open(header_file) as f:
         for line in f:


### PR DESCRIPTION
## Changes Implemented

The following changes were implemented in the code:

### 1. Scripts 0.1, 2.2, and `compute_relatedness`
- KING is now run before PC-Relate to improve relatedness inference.

### 2. Script 2.3
- Only the reference dataset is LD-pruned.
- The input was changed to use the filtered matrix produced in step 2.2.

### 3. Script `pca_utils`
- A new script was added to avoid repeating the same function definitions across:
  - script 2.2  
  - script 2.3  
  - `compute_relatedness`

### 4. Script 4.2
- An optional sex chromosome–specific filter is applied to chromosomes X and Y in male samples.

### 5. Scripts 4.3a and 4.3b
- Variants with `AC == 0` are removed.
- Script 4.3b can now produce VCFs using a specified filter level:
  - `relaxed`
  - `medium`
  - `stringent`  
  (previously, only `stringent` was supported)

### 6. CSQ and consequence annotation (multiple scripts)

Affected scripts:
- 3.5  
- 4.1  
- 4.2  
- 4.3a  
- 4.3b  
- 4.4  
- `vcf_utils`

Changes:
- CSQ and consequence annotations are now **optional**
- Only **one file** containing:
  - CSQs  
  - consequences  
  - genes  
  - HGNC IDs  
  is required to run the pipeline
- Scripts automatically:
  - detect the consequence column  
  - select synonymous variants  
  - annotate the matrix accordingly  

### 7. Config updates
- Config files were updated to support all changes listed above.

---

## To Do

The public dataset and test dataset require a new file:

`${general.dataset_name}.csq_header.txt`

This file must contain a CSQ header like:
```
##INFO=<ID=CSQ,Number=A,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE|MANE_SELECT|MANE_PLUS_CLINICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|UNIPROT_ISOFORM|SOURCE|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|gnomADe_AF|gnomADe_AFR_AF|gnomADe_AMR_AF|gnomADe_ASJ_AF|gnomADe_EAS_AF|gnomADe_FIN_AF|gnomADe_MID_AF|gnomADe_NFE_AF|gnomADe_REMAINING_AF|gnomADe_SAS_AF|gnomADg_AF|gnomADg_AFR_AF|gnomADg_AMI_AF|gnomADg_AMR_AF|gnomADg_ASJ_AF|gnomADg_EAS_AF|gnomADg_FIN_AF|gnomADg_MID_AF|gnomADg_NFE_AF|gnomADg_REMAINING_AF|gnomADg_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|TRANSCRIPTION_FACTORS|CADD_PHRED|CADD_RAW|LoF|LoF_filter|LoF_flags|LoF_info|REVEL|SpliceAI_pred_DP_AG|SpliceAI_pred_DP_AL|SpliceAI_pred_DP_DG|SpliceAI_pred_DP_DL|SpliceAI_pred_DS_AG|SpliceAI_pred_DS_AL|SpliceAI_pred_DS_DG|SpliceAI_pred_DS_DL|SpliceAI_pred_SYMBOL|AA|OpenTargets_geneId|OpenTargets_geneName|OpenTargets_geneSymbol|OpenTargets_l2g|LoFtool|am_class|am_pathogenicity|ClinVar|ClinVar_CLNDN|ClinVar_CLNDNINCL|ClinVar_CLNDISDB|ClinVar_CLNDISDBINCL|ClinVar_AF_ESP|ClinVar_AF_EXAC|ClinVar_AF_TGP|ClinVar_ALLELEID|ClinVar_CLNDN|ClinVar_CLNDNINCL|ClinVar_CLNDISDB|ClinVar_CLNDISDBINCL|ClinVar_CLNHGVS|ClinVar_CLNREVSTAT|ClinVar_CLNSIG|ClinVar_CLNSIGCONF|ClinVar_CLNSIGINCL|ClinVar_CLNVC|ClinVar_CLNVCSO|ClinVar_CLNVI|ClinVar_DBVARID|ClinVar_GENEINFO|ClinVar_MC|ClinVar_ORIGIN|ClinVar_RS|ClinVar_SSR">
```